### PR TITLE
feat(network): expose services via Netbird and add ingress allow rules

### DIFF
--- a/kubernetes/apps/base/authentik/helm.yaml
+++ b/kubernetes/apps/base/authentik/helm.yaml
@@ -76,6 +76,10 @@ spec:
         serviceMonitor:
           enabled: true
 
+      service:
+        annotations:
+          netbird.io/expose: "true"
+
       route:
         main:
           enabled: true

--- a/kubernetes/apps/base/authentik/network.yaml
+++ b/kubernetes/apps/base/authentik/network.yaml
@@ -107,6 +107,14 @@ spec:
         - ports:
             - port: https
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: netbird
+            app.kubernetes.io/name: netbird-router
+      toPorts:
+        - ports:
+            - port: http
+              protocol: TCP
   egress:
     - toEntities:
         - world

--- a/kubernetes/apps/base/immich/helm.yaml
+++ b/kubernetes/apps/base/immich/helm.yaml
@@ -173,6 +173,8 @@ spec:
 
     service:
       api:
+        annotations:
+          netbird.io/expose: "true"
         controller: api
         primary: true
         ports:

--- a/kubernetes/apps/base/immich/network.yaml
+++ b/kubernetes/apps/base/immich/network.yaml
@@ -97,6 +97,16 @@ spec:
             - port: http
               protocol: TCP
 
+    # Netbird to immich
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: netbird
+            app.kubernetes.io/name: netbird-router
+      toPorts:
+        - ports:
+            - port: http
+              protocol: TCP
+
     # Alloy to immich
     - fromEndpoints:
         - matchLabels:

--- a/kubernetes/apps/base/joplin/helm.yaml
+++ b/kubernetes/apps/base/joplin/helm.yaml
@@ -64,6 +64,8 @@ spec:
     service:
       main:
         controller: main
+        annotations:
+          netbird.io/expose: "true"
         ports:
           http:
             port: 80

--- a/kubernetes/apps/base/joplin/network.yaml
+++ b/kubernetes/apps/base/joplin/network.yaml
@@ -63,6 +63,14 @@ spec:
         - ports:
             - port: http
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: netbird
+            app.kubernetes.io/name: netbird-router
+      toPorts:
+        - ports:
+            - port: http
+              protocol: TCP
   egress:
     - toFQDNs:
         - matchName: "pool.ntp.org"

--- a/kubernetes/apps/base/openwebui/helm.yaml
+++ b/kubernetes/apps/base/openwebui/helm.yaml
@@ -94,6 +94,8 @@ spec:
     service:
       main:
         controller: main
+        annotations:
+          netbird.io/expose: "true"
         ports:
           http:
             port: 80

--- a/kubernetes/apps/base/openwebui/network.yaml
+++ b/kubernetes/apps/base/openwebui/network.yaml
@@ -85,6 +85,14 @@ spec:
         - ports:
             - port: http
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: netbird
+            app.kubernetes.io/name: netbird-router
+      toPorts:
+        - ports:
+            - port: http
+              protocol: TCP
   egress:
     - toEntities:
         - world

--- a/kubernetes/apps/base/paperless/helm.yaml
+++ b/kubernetes/apps/base/paperless/helm.yaml
@@ -121,6 +121,8 @@ spec:
 
     service:
       main:
+        annotations:
+          netbird.io/expose: "true"
         controller: main
         ports:
           http:

--- a/kubernetes/apps/base/paperless/network.yaml
+++ b/kubernetes/apps/base/paperless/network.yaml
@@ -85,6 +85,14 @@ spec:
         - ports:
             - port: http
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: netbird
+            app.kubernetes.io/name: netbird-router
+      toPorts:
+        - ports:
+            - port: http
+              protocol: TCP
   egress:
     - toFQDNs:
         - matchName: debian.map.fastlydns.net

--- a/kubernetes/apps/base/termix/helm.yaml
+++ b/kubernetes/apps/base/termix/helm.yaml
@@ -63,6 +63,8 @@ spec:
     service:
       main:
         controller: main
+        annotations:
+          netbird.io/expose: "true"
         ports:
           http:
             port: 80

--- a/kubernetes/apps/base/uptime/helm.yaml
+++ b/kubernetes/apps/base/uptime/helm.yaml
@@ -58,6 +58,8 @@ spec:
 
     service:
       main:
+        annotations:
+          netbird.io/expose: "true"
         controller: main
         ports:
           http:

--- a/kubernetes/apps/base/uptime/network.yaml
+++ b/kubernetes/apps/base/uptime/network.yaml
@@ -43,6 +43,14 @@ spec:
         - ports:
             - port: http
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: netbird
+            app.kubernetes.io/name: netbird-router
+      toPorts:
+        - ports:
+            - port: http
+              protocol: TCP
   egress:
     - toCIDR:
         - 192.168.30.20/32

--- a/kubernetes/apps/base/vaultwarden/helm.yaml
+++ b/kubernetes/apps/base/vaultwarden/helm.yaml
@@ -79,6 +79,8 @@ spec:
     # -- Configures service settings for the chart.
     service:
       main:
+        annotations:
+          netbird.io/expose: "true"
         controller: main
         sessionAffinity: ClientIP
         sessionAffinityConfig:

--- a/kubernetes/apps/base/vaultwarden/network.yaml
+++ b/kubernetes/apps/base/vaultwarden/network.yaml
@@ -64,6 +64,14 @@ spec:
         - ports:
             - port: http
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: netbird
+            app.kubernetes.io/name: netbird-router
+      toPorts:
+        - ports:
+            - port: http
+              protocol: TCP
   egress:
     - toFQDNs:
         - matchName: smtp.gmail.com


### PR DESCRIPTION
## Summary

- Added `netbird.io/expose: true` annotation to HelmReleases for 7 apps: authentik, immich, joplin, openwebui, paperless, termix, uptime, vaultwarden
- Added Netbird ingress allow rules to `CiliumNetworkPolicy` for each exposed app, permitting traffic from `netbird-router` pods in the `netbird` namespace on the `http` port

## Apps affected

- authentik
- immich
- joplin
- openwebui
- paperless
- termix
- uptime
- vaultwarden