### PR TITLE
feat(joplin): migrate pgcluster to ceph storage

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -19,6 +19,8 @@ Docker Compose services running on the management node, managed through GitOps p
 | [Stirling PDF](https://stirlingtools.com/)                | Self-hosted PDF manipulation tools                                                          |
 | [Peanut](https://github.com/brandawg93/peanut)            | UPS monitoring and management                                                               |
 | [Speedtest Tracker](https://docs.speedtest-tracker.dev/)  | Continuous internet speed monitoring (backed by PostgreSQL)                                 |
+| [Arcane](https://getarcane.app/)                          | Docker management UI with OIDC SSO (backed by PostgreSQL)                                   |
+| [cAdvisor](https://github.com/google/cadvisor)            | Container resource usage and performance metrics exporter                                   |
 
 ## Directory Structure
 
@@ -37,5 +39,7 @@ docker/
     ├── it-tools/
     ├── stirling-pdf/
     ├── peanut/
-    └── speedtracker/
+    ├── speedtracker/
+    ├── arcane/
+    └── cadvisor/
 ```

--- a/docker/mgmt/.doco-cd.yaml
+++ b/docker/mgmt/.doco-cd.yaml
@@ -57,3 +57,8 @@ name: arcane
 working_dir: docker/mgmt/arcane
 compose_files:
   - compose.yaml
+---
+name: cadvisor
+working_dir: docker/mgmt/cadvisor
+compose_files:
+  - compose.yaml

--- a/docker/mgmt/.doco-cd.yaml
+++ b/docker/mgmt/.doco-cd.yaml
@@ -23,11 +23,6 @@ working_dir: docker/mgmt/omada-controller
 compose_files:
   - compose.yaml
 ---
-name: dockhand
-working_dir: docker/mgmt/dockhand
-compose_files:
-  - compose.yaml
----
 name: peanut
 working_dir: docker/mgmt/peanut
 compose_files:
@@ -55,5 +50,10 @@ compose_files:
 ---
 name: databasus
 working_dir: docker/mgmt/databasus
+compose_files:
+  - compose.yaml
+---
+name: arcane
+working_dir: docker/mgmt/arcane
 compose_files:
   - compose.yaml

--- a/docker/mgmt/arcane/.env
+++ b/docker/mgmt/arcane/.env
@@ -1,0 +1,14 @@
+INTERNAL_DOMAIN=ENC[AES256_GCM,data:+gT2FLfTRtJnl1fjy6J3kpkS4RI=,iv:QVEW4iXC2KIKUpuKzLvaprGeX7fTRtaHrSUMjVJvN0o=,tag:5HmugICssfEHxnyHNj0gGA==,type:str]
+JWT_SECRET=ENC[AES256_GCM,data:qhAIWqWMZlxBVJIcdPAjfIPo0/drHHw6bE7CmOrSn7s01pvqFJp5QEJ5tVkx++0BO4K9F/vVCg0ZFGqSwWM50g==,iv:FmjtTV92ouUIR9d6+oGyVaLcoGZ/WAcq20coQXZPk/M=,tag:tgVevJfGaBt35A8rjU90Yw==,type:str]
+ENCRYPTION_KEY=ENC[AES256_GCM,data:U1cylg1+WW9sulO/QcuMXOms+WIbrtdNYa+o+poQvLwZcAYpSUSYeLvN9tGjmpXXRJFl8bbR5XvggvcJVSUE4g==,iv:JD4W3ITxqoPwaJTniuxUbApDyO/Y0pRoDeDzNqJvROg=,tag:6zgXsWUxHfi/vTq+VBpFYw==,type:str]
+TIMEZONE=ENC[AES256_GCM,data:3o5H7aoKCXX7S/l14A==,iv:gA/8IW5tbC5BjWwxP3esoKAwLxK1dp9PIBG4AYogF8Q=,tag:HE5QL3pWMhI2XxN8OdntgA==,type:str]
+OIDC_CLIENT_ID=ENC[AES256_GCM,data:O7hTR6CGtcklHp5ds5m5tOuYiGACc1P4Lc4DtJfd3skIpgUC+arEtw==,iv:Kmequ4UbL9P4sdfp2J8j82ymo+vb/qqWelNf0XXCuW4=,tag:hF//FZ05Ob+EZspvEXlb5A==,type:str]
+OIDC_CLIENT_SECRET=ENC[AES256_GCM,data:ITTEeIpgT13MKZiC1w4I0y+NkhxjlMD2fFCd53ek/ciU5Kv/3GI4xNmZ86uH6Aba15fr3yMQ4XOFecSjtm4tww6Bc0qPhcZaVCbqpMb9SDyqxRbVmFwGWPNI5DIHIjDM3tu6dngtGqlWzl/4/GvTCE7zLApV0AMOlbGRVMS1Qc4=,iv:nxA/Utf+pGGv6Y1fiDr2O+m+uARduGGVKiNOBPh7Phs=,tag:xQCoaHcBBUlx/WmNLItL+A==,type:str]
+DB_USER=ENC[AES256_GCM,data:QwoCAtWY,iv:JbCS3JntxiPU7brsDPvIlIVaEyoWqHiU0vCpfaIPRXk=,tag:qG4Up+NW5Ko8osNzCHlRNA==,type:str]
+DB_PASSWORD=ENC[AES256_GCM,data:AOSXe3FhW0LEN4/N7ojnh5aL/Zkfj0jFzPtWCq55OYeZtZRJABnX+UyHqvZF8/RDDp2cH4iRWfIYfAnL3MT89w==,iv:LezF6jk5/NuBv8mhnnQFz1g0rLMV4uqHPfD3wFSizkc=,tag:uWnH7aGnLYC3dsP5ehUcOQ==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmd3doVjV3UCtlUmptS3M3\nZnRzTjBYUlNkR3dYVkRNVllZbkhDMUVNakR3CjYxUGVTeXhOR1hmeVJCQzFxc2ZW\nOW5ZWDZCbGE0dERKZEYzQzlId0pzM1UKLS0tIGJxcXFJK0JrNktrUDNTcVYrbkNB\nTVNVdG1FTFVCYW4vcitKbFBlTjBiYWsKipLB6AwVn1Wre/qYThGEe+wfKcP7J3b2\ntbnSCZRhgdMhLEKsvNxklmlh27dGNXhvm0nmcbz8Eg0Xq8xq7F+Xvg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1usemhw8v2nnr5nuxddrc7gsy3525hhv0na4hk2ur7tjara5cp90s7cpeen
+sops_lastmodified=2026-04-19T21:12:37Z
+sops_mac=ENC[AES256_GCM,data:x0wevhq3wuPuymluZ3f2nQp1f95rr+9hWaM/x9mE9kMU/D4pMQRoEDid/wBzM0jIb3YcccGf//siKHtjJNDS0xvH9TewKIKg2aunZ7mPraMGjV2OvyOHKUyLyF2YGmESaxOBWNvPMQeewTah42+YD42X4go4Ke7IVSZIbB1H+tY=,iv:PLU0ydZXlJEuxq+uLMGoU4jbErFgl7TaecVObJaq/kM=,tag:GGB3ujeKvacv4lxVkcQ7HA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.12.2

--- a/docker/mgmt/arcane/compose.yaml
+++ b/docker/mgmt/arcane/compose.yaml
@@ -1,0 +1,133 @@
+services:
+  socket-proxy:
+    image: lscr.io/linuxserver/socket-proxy:3.2.15@sha256:a5a143133df569b6103bd555c18b3355d0def538272ab3c65936cc93ebe44368
+    container_name: arcane-socket-proxy
+    environment:
+      - EVENTS=1
+      - PING=1
+      - VERSION=1
+      # Security critical
+      - AUTH=0
+      - SECRETS=0
+      - POST=1
+      # Not always needed
+      - BUILD=0
+      - COMMIT=0
+      - CONFIGS=0
+      - CONTAINERS=1
+      - DISTRIBUTION=0
+      - EXEC=1
+      - IMAGES=1
+      - INFO=1
+      - NETWORKS=1
+      - NODES=0
+      - PLUGINS=0
+      - SERVICES=0
+      - SESSION=0
+      - SWARM=0
+      - SYSTEM=0
+      - TASKS=0
+      - VOLUMES=1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - default
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /run
+
+  arcane:
+    image: ghcr.io/getarcaneapp/arcane:v1.17.4@sha256:97492274e59c9f822a9c49d67981912b81919c0edad6094e496fa3507348082e
+    container_name: arcane
+    volumes:
+      - data:/app/data
+    environment:
+      TZ: ${TIMEZONE}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      JWT_SECRET: ${JWT_SECRET}
+      DOCKER_HOST: tcp://socket-proxy:2375
+      DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@db:5432/arcane
+      OIDC_ENABLED: true
+      OIDC_AUTO_REDIRECT_TO_PROVIDER: true
+      OIDC_PROVIDER_NAME: authentik
+      OIDC_ISSUER_URL: https://authentik.${INTERNAL_DOMAIN}/application/o/arcane/
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET}
+      OIDC_MERGE_ACCOUNTS: true
+      OIDC_ADMIN_CLAIM: groups
+      OIDC_ADMIN_VALUE: AuthentikAdmins
+    networks:
+      - default
+      - proxy
+    depends_on:
+      socket-proxy:
+        condition: service_started
+      db:
+        condition: service_healthy
+        restart: true
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -fsS http://localhost:3552/api/health >/dev/null || exit 1']
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.arcane.rule=Host(`arcane.${INTERNAL_DOMAIN}`)"
+      - "traefik.http.routers.arcane.entrypoints=websecure"
+      - "traefik.http.routers.arcane.tls.certresolver=letsencrypt"
+      - "traefik.http.services.arcane.loadbalancer.server.port=3552"
+      - "traefik.http.services.arcane.loadbalancer.server.scheme=http"
+    restart: unless-stopped
+    user: "1000:1000"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+
+  db:
+    container_name: arcane-db
+    image: postgres:18.3-alpine@sha256:c5739fc99d1a3278c0a2113758a2433ce29ef964b30df705094fd77dfa5da2fa
+    restart: always
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: arcane
+    volumes:
+      - db_data:/var/lib/postgresql
+    networks:
+      - default
+      - database
+    healthcheck:
+      test: "pg_isready --username=${DB_USER} && psql --username=${DB_USER} --list"
+      interval: 5s
+      timeout: 10s
+      retries: 10
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - DAC_READ_SEARCH
+
+networks:
+  default:
+  database:
+    external: true
+  proxy:
+    external: true
+
+volumes:
+  data:
+    driver: local
+  db_data:
+    driver: local

--- a/docker/mgmt/cadvisor/.env
+++ b/docker/mgmt/cadvisor/.env
@@ -1,0 +1,7 @@
+INTERNAL_DOMAIN=ENC[AES256_GCM,data:X41ehJbrpB+5kB7Itd6bQgTG8Os=,iv:ub2Yya5znCooZXZtVwxXtEpGJtcOIBPdmWDQAGmICJI=,tag:0blZdBr7GzI0lVFICAVLEA==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2cVZVcjZmMC9ZQ2NiT3NI\nUlJpQkZSbjRGaGJUUC9sR0tEYmJ1VStlVkZzCjNGd1ZXOGVIYzFYZ0xSUkk5bGRQ\nUnpEbWdQR0xOdE4zalNMR25KMkJPVVkKLS0tIEI5Rm8rOUJFUUsvUkIwVFN5a1lh\ndFdESUI4bkhPUFdwWlU2ZjNRRHArbU0KEEWMg5zq4IwCfYl8hLN6LlUdD3G8YZ3F\nqLTV+xbkZqHufXvzWny5qv/3S5ae8X6QfYrpIDT9/hPzR5pGuCkbpg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1usemhw8v2nnr5nuxddrc7gsy3525hhv0na4hk2ur7tjara5cp90s7cpeen
+sops_lastmodified=2026-04-20T11:26:25Z
+sops_mac=ENC[AES256_GCM,data:wyoYyxFgIb/WAxMWkxP6ngGHJcFu3V+zamiZn40YfU0r2n9512kCO/3HBc2MhA2sUgYHlng2KdAX0hfzRbgGgohl5lYDk3yuQiPKuJ1xe5R/JVCFwF+skx1BJzVciChWqH9G0Fy0DiqKcZc2WU8BZfIXJcZAixSgK70d6G61Gy0=,iv:oOt9fKXs2QxVlVTp845GOWumYaLcqko915jRiEPYwow=,tag:YZ1sz32/8QoTwMff2O+iXA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.12.2

--- a/docker/mgmt/cadvisor/compose.yaml
+++ b/docker/mgmt/cadvisor/compose.yaml
@@ -1,0 +1,29 @@
+services:
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.55.1@sha256:3de2bd5203120b866d74a9b283b2ffb8ec382fbf9dc321814700c6ea6f44ec57
+    container_name: cadvisor
+    restart: unless-stopped
+    privileged: true  # required for cgroup and device access — cap_drop has no effect when privileged
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - /:/rootfs:ro
+      - /sys:/sys:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /dev/disk:/dev/disk:ro
+      - /etc/machine-id:/etc/machine-id:ro
+      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id:ro
+      - /var/lib/containers:/var/lib/containers:ro
+      - /var/run:/var/run:ro
+    ports:
+      - "8080:8080"
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.15"
+          memory: &memory 256M
+        limits:
+          memory: *memory

--- a/kubernetes/apps/base/joplin/pgcluster.yaml
+++ b/kubernetes/apps/base/joplin/pgcluster.yaml
@@ -7,10 +7,10 @@ metadata:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
-  instances: 3
+  instances: 2
   primaryUpdateStrategy: unsupervised
   storage:
-    storageClass: local-path
+    storageClass: ceph-block
     size: 5Gi
 
   bootstrap:

--- a/kubernetes/apps/overlays/prd/kustomization.yaml
+++ b/kubernetes/apps/overlays/prd/kustomization.yaml
@@ -20,5 +20,5 @@ resources:
   - ../../base/searxng
   - ../../base/termix
   - ../../base/uptime
-  - ../../base/vault
+  # - ../../base/vault
   - ../../base/vaultwarden

--- a/kubernetes/infrastructure/base/networking/envoy-gateway/config/envoy.yaml
+++ b/kubernetes/infrastructure/base/networking/envoy-gateway/config/envoy.yaml
@@ -13,6 +13,8 @@ spec:
         replicas: 2
         container:
           image: mirror.gcr.io/envoyproxy/envoy:v1.37.2
+      envoyService:
+        externalTrafficPolicy: Cluster
   shutdown:
     drainTimeout: 180s
   telemetry:

--- a/kubernetes/infrastructure/base/observability/alloy/app/dashboards/cadvisor.json
+++ b/kubernetes/infrastructure/base/observability/alloy/app/dashboards/cadvisor.json
@@ -1,0 +1,1051 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.3.1"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Docker monitoring with Prometheus and cAdvisor with node and service selection",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Grafana",
+      "tooltip": "",
+      "type": "link",
+      "url": "https://grafana.com/grafana/dashboards/15798"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(container_last_seen{instance=~\"$node\",job=~\"$job\", service=~\"$service\", container=~\"$container\",image!=\"\"})",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "metric": "container_last_seen",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Running containers",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "mbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 4,
+        "y": 0
+      },
+      "id": 5,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(container_memory_usage_bytes{instance=~\"$node\", service=~\"$service\",job=~\"$job\", container=~\"$container\",image!=\"\"})/1024/1024",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "metric": "container_memory_usage_bytes",
+          "range": true,
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Container Memory Usage",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "mbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 9,
+        "y": 0
+      },
+      "id": 9,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum(machine_memory_bytes{instance=~\"$node\",job=~\"$job\"})/1024/1024",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "metric": "container_memory_usage_bytes",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Total Memory",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
+      "id": 6,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(container_cpu_usage_seconds_total{instance=~\"$node\",job=~\"$job\", service=~\"$service\", container=~\"$container\",image!=\"\"}[$__rate_interval]) * 100) ",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "metric": "container_memory_usage_bytes",
+          "range": true,
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Container CPU Usage",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
+      "id": 10,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "sum(machine_cpu_cores{instance=~\"$node\",job=~\"$job\"})",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "metric": "container_memory_usage_bytes",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "CPU Cores",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": 600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{instance=~\"$node\",job=~\"$job\",image!=\"\", service=~\"$service\", container=~\"$container\"}[$__rate_interval]) ) * 100 ",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{name}}",
+          "metric": "cpu",
+          "range": true,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": 600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (container) (container_memory_usage_bytes{instance=~\"$node\",job=~\"$job\",image!=\"\", service=~\"$service\", container=~\"$container\"})",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{name}}",
+          "metric": "container_memory_usage_bytes",
+          "range": true,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": 600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "sum",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (container) (rate(container_network_receive_bytes_total{instance=~\"$node\",job=~\"$job\",image!=\"\", service=~\"$service\", container=~\"$container\"}[$__rate_interval]))",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "recv {{container}}",
+          "metric": "container_network_receive_bytes_total",
+          "range": true,
+          "refId": "recv",
+          "step": 20
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "-(sum by (container) (rate(container_network_transmit_bytes_total{instance=~\"$node\",job=~\"$job\",image!=\"\", service=~\"$service\", container=~\"$container\"}[$__rate_interval])))",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "trans {{container}}",
+          "range": true,
+          "refId": "trans"
+        }
+      ],
+      "title": "Network",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": 600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "sum",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (container) (rate(container_fs_reads_bytes_total{instance=~\"$node\",job=~\"$job\",image!=\"\", service=~\"$service\", container=~\"$container\"}[$__rate_interval]))",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "read {{container}}",
+          "metric": "container_fs_reads_bytes_total",
+          "range": true,
+          "refId": "read",
+          "step": 20
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "-(sum by (container) (rate(container_fs_writes_bytes_total{instance=~\"$node\",job=~\"$job\",image!=\"\", service=~\"$service\", container=~\"$container\"}[$__rate_interval])))",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "write {{container}}",
+          "range": true,
+          "refId": "write"
+        }
+      ],
+      "title": "Disk I/O",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 42,
+  "tags": [
+    "docker",
+    "cadvisor",
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(container_memory_usage_bytes{image!=\"\"}, job)",
+        "description": "",
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(container_memory_usage_bytes{image!=\"\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(container_memory_usage_bytes{job=~\"$job\", image!=\"\"},instance)",
+        "description": "",
+        "includeAll": true,
+        "label": "Host",
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(container_memory_usage_bytes{job=~\"$job\", image!=\"\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(container_memory_usage_bytes{job=~\"$job\", image!=\"\", instance=~\"$node\"},service)",
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(container_memory_usage_bytes{job=~\"$job\", image!=\"\", instance=~\"$node\"},service)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(container_memory_usage_bytes{job=~\"$job\", image!=\"\", service=~\"$service\", instance=~\"$node\"},container)",
+        "includeAll": true,
+        "label": "Container",
+        "multi": true,
+        "name": "container",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(container_memory_usage_bytes{job=~\"$job\", image!=\"\", service=~\"$service\", instance=~\"$node\"},container)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Docker monitoring",
+  "uid": "m0arCBf7k",
+  "version": 2,
+  "weekStart": "",
+  "id": null
+}

--- a/kubernetes/infrastructure/base/observability/alloy/app/kustomization.yaml
+++ b/kubernetes/infrastructure/base/observability/alloy/app/kustomization.yaml
@@ -14,3 +14,11 @@ configMapGenerator:
         app.kubernetes.io/component: config
     files:
       - config.alloy
+
+  - name: dashboards
+    options:
+      disableNameSuffixHash: true
+      labels:
+        grafana/dashboard: "true"
+    files:
+      - dashboards/cadvisor.json

--- a/kubernetes/infrastructure/base/observability/alloy/app/scrapeconfig.yaml
+++ b/kubernetes/infrastructure/base/observability/alloy/app/scrapeconfig.yaml
@@ -15,3 +15,28 @@ spec:
     - action: replace
       targetLabel: job
       replacement: node-exporter
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: external-cadvisor
+  namespace: monitoring
+spec:
+  staticConfigs:
+    - targets:
+        - mgmt.${INTERNAL_DOMAIN}:8080
+        - truenas.${INTERNAL_DOMAIN}:8080
+  metricsPath: /metrics
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: cadvisor
+  metricRelabelings:
+    - action: replace
+      sourceLabels: [name]
+      targetLabel: container
+    - action: replace
+      sourceLabels: [container_label_com_docker_compose_project]
+      targetLabel: service
+    - action: labeldrop
+      regex: id


### PR DESCRIPTION
## Summary

- Migrates Joplin's PostgreSQL cluster to Ceph-backed storage as a test for a future migration of all pgclusters
- The goal is to reduce the memory footprint across all clusters by consolidating storage on Ceph

## Motivation

The Kubernetes hosts are VMs, and two of them share the same physical host. This means a primary and replica pod could end up on the same physical machine — if that host goes down, the entire pgcluster is unavailable with no way to recover on another node.

By migrating to Ceph storage with its built-in replication, the cluster data remains accessible from any node. This allows a pgcluster to come back up on a different node even if the original physical host fails, eliminating that single point of failure.

## Plan

This PR serves as the test migration for Joplin. If successful, the same approach will be rolled out to all remaining pgclusters.