### PR TITLE
feat(joplin): migrate pgcluster to ceph storage

### DIFF
--- a/kubernetes/apps/base/joplin/pgcluster.yaml
+++ b/kubernetes/apps/base/joplin/pgcluster.yaml
@@ -7,10 +7,10 @@ metadata:
     cnpg.io/skipEmptyWalArchiveCheck: "enabled"
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
-  instances: 3
+  instances: 2
   primaryUpdateStrategy: unsupervised
   storage:
-    storageClass: local-path
+    storageClass: ceph-block
     size: 5Gi
 
   bootstrap:


### PR DESCRIPTION
## Summary

- Migrates Joplin's PostgreSQL cluster to Ceph-backed storage as a test for a future migration of all pgclusters
- The goal is to reduce the memory footprint across all clusters by consolidating storage on Ceph

## Motivation

The Kubernetes hosts are VMs, and two of them share the same physical host. This means a primary and replica pod could end up on the same physical machine — if that host goes down, the entire pgcluster is unavailable with no way to recover on another node.

By migrating to Ceph storage with its built-in replication, the cluster data remains accessible from any node. This allows a pgcluster to come back up on a different node even if the original physical host fails, eliminating that single point of failure.

## Plan

This PR serves as the test migration for Joplin. If successful, the same approach will be rolled out to all remaining pgclusters.