### PR TITLE
feat(cnpg): add required pod anti-affinity to all pgclusters

### DIFF
--- a/kubernetes/apps/base/authentik/pgcluster.yaml
+++ b/kubernetes/apps/base/authentik/pgcluster.yaml
@@ -9,6 +9,8 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
   instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
   storage:
     storageClass: ceph-block
     size: 2Gi

--- a/kubernetes/apps/base/harbor/pgcluster.yaml
+++ b/kubernetes/apps/base/harbor/pgcluster.yaml
@@ -9,6 +9,8 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
   instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
   storage:
     storageClass: ceph-block
     size: 5Gi

--- a/kubernetes/apps/base/immich/pgcluster.yaml
+++ b/kubernetes/apps/base/immich/pgcluster.yaml
@@ -9,6 +9,8 @@ spec:
   imageName: ghcr.io/tensorchord/cloudnative-vectorchord:17-0.4.3
   instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
   storage:
     storageClass: ceph-block
     size: 10Gi

--- a/kubernetes/apps/base/joplin/pgcluster.yaml
+++ b/kubernetes/apps/base/joplin/pgcluster.yaml
@@ -9,6 +9,8 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
   instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
   storage:
     storageClass: ceph-block
     size: 5Gi

--- a/kubernetes/apps/base/n8n/pgcluster.yaml
+++ b/kubernetes/apps/base/n8n/pgcluster.yaml
@@ -9,6 +9,8 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
   instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
   storage:
     storageClass: ceph-block
     size: 5Gi

--- a/kubernetes/apps/base/netbox/pgcluster.yaml
+++ b/kubernetes/apps/base/netbox/pgcluster.yaml
@@ -9,6 +9,8 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
   instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
   storage:
     storageClass: ceph-block
     size: 5Gi

--- a/kubernetes/apps/base/openwebui/pgcluster.yaml
+++ b/kubernetes/apps/base/openwebui/pgcluster.yaml
@@ -9,6 +9,8 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
   instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
   storage:
     storageClass: ceph-block
     size: 5Gi

--- a/kubernetes/apps/base/paperless/pgcluster.yaml
+++ b/kubernetes/apps/base/paperless/pgcluster.yaml
@@ -9,6 +9,8 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
   instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
   storage:
     storageClass: ceph-block
     size: 5Gi

--- a/kubernetes/apps/base/vaultwarden/pgcluster.yaml
+++ b/kubernetes/apps/base/vaultwarden/pgcluster.yaml
@@ -9,6 +9,8 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.9-standard-trixie
   instances: 2
   primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
   storage:
     storageClass: ceph-block
     size: 2Gi


### PR DESCRIPTION
## Summary

- Added  to all 9 PGCluster definitions
- Ensures no two instances of the same PGCluster can be scheduled on the same Kubernetes node
- Uses CNPG's built-in  which generates a  rule on 

## Affected clusters

authentik, harbor, immich, joplin, n8n, netbox, openwebui, paperless, vaultwarden