### PR TITLE
fix(prometheus): revert kube-prometheus-stack to v83 to avoid duplicate thanos image key bug

### DIFF
--- a/kubernetes/infrastructure/base/observability/prometheus/operator/helm.yaml
+++ b/kubernetes/infrastructure/base/observability/prometheus/operator/helm.yaml
@@ -18,7 +18,7 @@ spec:
   sourceRef:
     kind: HelmRepository
     name: prometheus
-  version: 84.*
+  version: 83.*
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
## Summary

Fixes the Helm upgrade failure:
```
error while running post render on manifests: yaml: unmarshal errors:
  line 101: mapping key "image" already defined at line 98
```

**Root cause:** The `kube-prometheus-stack` chart v84.x has a template bug in `prometheus.yaml` lines 407-411. It renders `thanos.image` explicitly via `{{- with .Values.prometheus.prometheusSpec.thanos.image }}`, then renders ALL remaining thanos fields via `toYaml` — but doesn't omit `image` from the `omit()` call. This produces a duplicate `image` key in the rendered YAML.

`helm template` outputs the invalid YAML without error, but Flux's post-render step unmarshals it with Go's YAML parser (strict on duplicate keys), causing the failure.

**Fix:** Revert to chart version `83.*` which renders `thanos.image` correctly (single pass via `toYaml`). The thanos sidecar image value is unchanged (`quay.io/thanos/thanos:v0.41.0`).

**Chart bug:** https://github.com/prometheus-community/helm-charts — duplicate `image` key when `prometheus.prometheusSpec.thanos.image` is set in v84.x