### PR TITLE
feat: add hostname anti-affinity to all dragonfly and harbor replicas

### DIFF
--- a/kubernetes/apps/base/harbor/dragonfly.yaml
+++ b/kubernetes/apps/base/harbor/dragonfly.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.38.1@sha256:baf70ba7ad182a992b988497cfa31a488978c8fab7712079784c2401f447e402
   replicas: 2
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: harbor-dragonfly
   env:
     - name: MAX_MEMORY
       valueFrom:

--- a/kubernetes/apps/base/harbor/helm.yaml
+++ b/kubernetes/apps/base/harbor/helm.yaml
@@ -30,6 +30,13 @@ spec:
 
     core:
       replicas: 2
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              component: core
       existingSecret: harbor-core-secret
       existingXsrfSecret: harbor-core-csrf
       secretName: harbor-token-encryption
@@ -42,6 +49,13 @@ spec:
 
     jobservice:
       replicas: 2
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              component: jobservice
       existingSecret: harbor-jobservice-secret
       existingSecretKey: secret
       jobLoggers:
@@ -55,6 +69,13 @@ spec:
 
     registry:
       replicas: 2
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              component: registry
       existingSecret: harbor-registry-secret
       existingSecretKey: secret
       credentials:

--- a/kubernetes/apps/base/immich/dragonfly.yaml
+++ b/kubernetes/apps/base/immich/dragonfly.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.38.1@sha256:baf70ba7ad182a992b988497cfa31a488978c8fab7712079784c2401f447e402
   replicas: 2
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: immich-dragonfly
   env:
     - name: MAX_MEMORY
       valueFrom:

--- a/kubernetes/apps/base/netbox/dragonfly.yaml
+++ b/kubernetes/apps/base/netbox/dragonfly.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.38.1@sha256:baf70ba7ad182a992b988497cfa31a488978c8fab7712079784c2401f447e402
   replicas: 2
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: netbox-dragonfly
   env:
     - name: MAX_MEMORY
       valueFrom:

--- a/kubernetes/apps/base/openwebui/dragonfly.yaml
+++ b/kubernetes/apps/base/openwebui/dragonfly.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.38.1@sha256:baf70ba7ad182a992b988497cfa31a488978c8fab7712079784c2401f447e402
   replicas: 2
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: openwebui-dragonfly
   env:
     - name: MAX_MEMORY
       valueFrom:

--- a/kubernetes/apps/base/paperless/dragonfly.yaml
+++ b/kubernetes/apps/base/paperless/dragonfly.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.38.1@sha256:baf70ba7ad182a992b988497cfa31a488978c8fab7712079784c2401f447e402
   replicas: 2
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: paperless-dragonfly
   env:
     - name: MAX_MEMORY
       valueFrom:

--- a/kubernetes/apps/base/searxng/dragonfly.yaml
+++ b/kubernetes/apps/base/searxng/dragonfly.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.38.1@sha256:baf70ba7ad182a992b988497cfa31a488978c8fab7712079784c2401f447e402
   replicas: 2
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: searxng-dragonfly
   env:
     - name: MAX_MEMORY
       valueFrom:


### PR DESCRIPTION
## Summary

Add  with  topology key and  policy to prevent replicas from being scheduled on the same node.

### Dragonfly instances (6 files)
- harbor, immich, netbox, openwebui, paperless, searxng
- Uses  label selector (matches the Dragonfly operator's pod labels)

### Harbor components (3 components)
- core (2 replicas), jobservice (2 replicas), registry (2 replicas)
- Uses  label selector (matches the Harbor Helm chart's pod labels)
- Trivy excluded (1 replica, anti-affinity not applicable)

### Pattern used
```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
    labelSelector:
      matchLabels:
        <component-specific-label>
```