### PR TITLE
fix(monitoring): remove non-existent cluster label from KRR job

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -30,5 +30,8 @@
   },
   "kubernetes": {
     "managerFilePatterns": ["/\\.yaml(?:\\.j2)?$/"]
+  },
+  "github-actions": {
+    "rangeStrategy": "pin"
   }
 }

--- a/kubernetes/infrastructure/base/observability/krr/app/krr.yaml
+++ b/kubernetes/infrastructure/base/observability/krr/app/krr.yaml
@@ -111,7 +111,7 @@ spec:
             - command:
                 - /bin/sh
                 - -c
-                - "python krr.py simple --max-workers 3 --width 2048 --history-duration 336 --prometheus-label cluster -l prd -v --mem-min 10 --cpu-min 5 --use-oomkill-data"
+                - "python krr.py simple --max-workers 3 --width 2048 --history-duration 336 -v --mem-min 10 --cpu-min 5 --use-oomkill-data"
               image: robustadev/krr:v1.28.0
               imagePullPolicy: Always
               name: krr


### PR DESCRIPTION
## Problem

The KRR CronJob was using `--prometheus-label cluster -l prd`, which filters Prometheus queries for metrics with the label `cluster=prd`. However, this label does not exist in the Prometheus configuration — the only `externalLabel` configured is `prometheus_replica: $(POD_NAME)`. As a result, KRR queries return no metrics.

## Changes

- **KRR**: Removed `--prometheus-label cluster -l prd` from the KRR command so it queries all metrics without filtering on a non-existent label
- **Renovate**: Added `"rangeStrategy": "pin"` for `github-actions` manager to improve version pinning

## Testing

- KRR job should now successfully discover and analyze metrics from Prometheus