### PR TITLE
fix(mgmt): prevent mongo crash on kernel 6.19+ with rseq tunable

### DIFF
--- a/docker/mgmt/omada-controller/compose.yaml
+++ b/docker/mgmt/omada-controller/compose.yaml
@@ -60,6 +60,7 @@ services:
     environment:
       TZ: Europe/Lisbon
       MONGO_INITDB_DATABASE: omada
+      GLIBC_TUNABLES: glibc.pthread.rseq=1
     networks:
       - default
     volumes:


### PR DESCRIPTION
## Problem

MongoDB 8.0+ crashes (SIGSEGV) on Linux kernel 6.19+ due to TCMalloc violating the upstream rseq ABI ([SERVER-121912](https://jira.mongodb.org/browse/SERVER-121912)).

## Fix

Set `GLIBC_TUNABLES=glibc.pthread.rseq=1` on the omada-controller mongo container.

Enabling glibc's rseq registration causes TCMalloc to detect that glibc already registered rseq and skip its own broken implementation, preventing the crash. This is the recommended workaround confirmed in [google/tcmalloc#292](https://github.com/google/tcmalloc/issues/292) and the [docker-library/mongo discussion](https://github.com/docker-library/mongo/discussions/748).

## References

- https://jira.mongodb.org/browse/SERVER-121912
- https://github.com/google/tcmalloc/issues/292
- https://miliucci.org/post/mongodb-tcmalloc-rseq/