### PR TITLE
fix: increase memory limits for OOMkilled workloads

### DIFF
--- a/kubernetes/apps/base/harbor/helm.yaml
+++ b/kubernetes/apps/base/harbor/helm.yaml
@@ -39,10 +39,10 @@ spec:
       secretName: harbor-token-encryption
       resources:
         requests:
-          memory: 192Mi
+          memory: &memory 256Mi
           cpu: 5m
         limits:
-          memory: 192Mi
+          memory: *memory
 
     jobservice:
       replicas: 2
@@ -56,10 +56,10 @@ spec:
         - stdout
       resources:
         requests:
-          memory: 150Mi
+          memory: &memory 150Mi
           cpu: 5m
         limits:
-          memory: 150Mi
+          memory: *memory
 
     registry:
       replicas: 2
@@ -74,42 +74,42 @@ spec:
       registry:
         resources:
           requests:
-            memory: &registryMemory 192Mi
+            memory: &memory 192Mi
             cpu: 5m
           limits:
-            memory: *registryMemory
+            memory: *memory
       controller:
         resources:
           requests:
             cpu: 5m
-            memory: &controllerMemory 32Mi
+            memory: &memory 40Mi
           limits:
-            memory: *controllerMemory
+            memory: *memory
 
     portal:
       resources:
         requests:
           cpu: 5m
-          memory: 20Mi
+          memory: &memory 20Mi
         limits:
-          memory: 20Mi
+          memory: *memory
 
     exporter:
       resources:
         requests:
           cpu: 5m
-          memory: 35Mi
+          memory: &memory 44Mi
         limits:
-          memory: 35Mi
+          memory: *memory
 
     trivy:
       replicas: 1
       resources:
         requests:
           cpu: 5m
-          memory: 1280Mi
+          memory: &memory 1280Mi
         limits:
-          memory: 1280Mi
+          memory: *memory
 
     expose:
       type: route

--- a/kubernetes/apps/base/netbox/helm.yaml
+++ b/kubernetes/apps/base/netbox/helm.yaml
@@ -38,7 +38,7 @@ spec:
     resources:
       requests:
         cpu: 50m
-        memory: &memory 1050Mi
+        memory: &memory 1300Mi
       limits:
         memory: *memory
 

--- a/kubernetes/infrastructure/base/observability/thanos/app/helm.yaml
+++ b/kubernetes/infrastructure/base/observability/thanos/app/helm.yaml
@@ -80,9 +80,9 @@ spec:
       resources:
         requests:
           cpu: 290m
-          memory: 512Mi
+          memory: &memory 650Mi
         limits:
-          memory: 512Mi
+          memory: *memory
       retentionResolutionRaw: 15d
       retentionResolution5m: 30d
       retentionResolution1h: 60d


### PR DESCRIPTION
## Summary

Increase memory limits for workloads that have been OOMkilled.

| Workload | Component | Before | After |
|----------|-----------|--------|-------|
| Harbor | core | 192Mi | 256Mi |
| Harbor | registry controller | 32Mi | 40Mi |
| Harbor | exporter | 35Mi | 44Mi |
| Netbox | netbox | 1050Mi | 1300Mi |
| Thanos | query | 512Mi | 650Mi |

Also standardizes YAML anchors (using `&memory`/`*memory`) across all Harbor components for consistency.