### PR TITLE
feat(kubernetes): add LiteLLM AI gateway

### DIFF
--- a/kubernetes/apps/base/litellm/dragonfly.yaml
+++ b/kubernetes/apps/base/litellm/dragonfly.yaml
@@ -1,0 +1,51 @@
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: litellm-dragonfly
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  image: ghcr.io/dragonflydb/dragonfly:v1.39.0@sha256:0fa01a2b929e704c7a9300d23e7f52002ebd39e90996fb8bb63826aed92fa06f
+  replicas: 2
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: litellm-dragonfly
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+  args:
+    - --maxmemory=$(MAX_MEMORY)Mi
+    - --proactor_threads=2
+  authentication:
+    passwordFromSecret:
+      name: litellm-dragonfly-credentials
+      key: DRAGONFLY_PASSWORD
+  resources:
+    requests:
+      cpu: 15m
+      memory: 50Mi
+    limits:
+      memory: 512Mi
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: &app litellm-dragonfly
+  labels:
+    group: dragonfly
+    app: *app
+spec:
+  selector:
+    matchLabels:
+      app: *app
+  podTargetLabels:
+    - app
+  podMetricsEndpoints:
+    - port: admin

--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -58,6 +58,10 @@ spec:
     ingress:
       enabled: false
 
+    service:
+      annotations:
+        netbird.io/expose: "true"
+
     # One Uvicorn worker per pod — scale horizontally via replicas (Kubernetes recommendation)
     numWorkers: 1
 
@@ -74,10 +78,6 @@ spec:
 
     proxy_config:
       model_list:
-        - model_name: gpt-4o
-          litellm_params:
-            model: openai/gpt-4o
-            api_key: os.environ/OPENAI_API_KEY
         # OpenAI image generation
         - model_name: gpt-image-2
           model_info:
@@ -98,10 +98,6 @@ spec:
           litellm_params:
             model: anthropic/claude-opus-4-8
             api_key: os.environ/ANTHROPIC_API_KEY
-        - model_name: gemini-2.5-flash
-          litellm_params:
-            model: gemini/gemini-2.5-flash
-            api_key: os.environ/GEMINI_API_KEY
         # Gemini image generation models
         - model_name: gemini-3.1-flash-image
           model_info:

--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -85,6 +85,16 @@ spec:
           litellm_params:
             model: openai/gpt-image-2
             api_key: os.environ/OPENAI_API_KEY
+        - model_name: tts
+          litellm_params:
+            model: openai/tts-1
+            api_key: os.environ/OPENAI_API_KEY
+        - model_name: whisper
+          litellm_params:
+            model: whisper-1
+            api_key: os.environ/OPENAI_API_KEY
+          model_info:
+            mode: audio_transcription
         # Anthropic models
         - model_name: claude-fable-5
           litellm_params:
@@ -207,6 +217,13 @@ spec:
         - model_name: github-copilot-gpt-5.4-mini
           litellm_params:
             model: github_copilot/gpt-5.4-mini
+        # Deepgram
+        - model_name: nova-2
+          litellm_params:
+            model: deepgram/nova-2
+            api_key: os.environ/DEEPGRAM_API_KEY
+          model_info:
+            mode: audio_transcription
 
       litellm_settings:
         drop_params: true

--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -1,0 +1,251 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: litellm-helm
+  namespace: litellm
+spec:
+  interval: 24h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.90.0
+  url: oci://ghcr.io/berriai/litellm-helm
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: litellm
+  namespace: litellm
+spec:
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  chartRef:
+    kind: OCIRepository
+    name: litellm-helm
+    namespace: litellm
+  values:
+    replicaCount: 2
+    strategy:
+      type: RollingUpdate
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+
+    image:
+      tag: v1.90.0@sha256:a50b02a6056095da29308310bb608f0509e08ddcd1d105bae9c21007d82b0e95
+
+    # Use external CloudNativePG — disable the bundled Bitnami postgres subchart
+    db:
+      deployStandalone: false
+      endpoint: litellm-cluster-rw
+      database: litellm
+      secret:
+        name: litellm-cluster-credentials
+        usernameKey: username
+        passwordKey: password
+
+    # Use external Dragonfly — disable the bundled Redis subchart
+    redis:
+      enabled: false
+
+    # We use Envoy Gateway HTTPRoute (see httproute.yaml) instead of Ingress
+    ingress:
+      enabled: false
+
+    # One Uvicorn worker per pod — scale horizontally via replicas (Kubernetes recommendation)
+    numWorkers: 1
+
+    # Turn off FastAPI's default info logs (production best practice)
+    logLevel: "ERROR"
+
+    # Enable Prometheus ServiceMonitor for metrics scraping
+    serviceMonitor:
+      enabled: true
+
+    # Inject master key, API keys, and Redis connection info as env vars
+    environmentSecrets:
+      - litellm-secret-env
+
+    proxy_config:
+      model_list:
+        - model_name: gpt-4o
+          litellm_params:
+            model: openai/gpt-4o
+            api_key: os.environ/OPENAI_API_KEY
+        # OpenAI image generation
+        - model_name: gpt-image-2
+          model_info:
+            mode: image_generation
+          litellm_params:
+            model: openai/gpt-image-2
+            api_key: os.environ/OPENAI_API_KEY
+        # Anthropic models
+        - model_name: claude-fable-5
+          litellm_params:
+            model: anthropic/claude-fable-5
+            api_key: os.environ/ANTHROPIC_API_KEY
+        - model_name: claude-sonnet-5
+          litellm_params:
+            model: anthropic/claude-sonnet-5
+            api_key: os.environ/ANTHROPIC_API_KEY
+        - model_name: claude-opus-4.8
+          litellm_params:
+            model: anthropic/claude-opus-4-8
+            api_key: os.environ/ANTHROPIC_API_KEY
+        - model_name: gemini-2.5-flash
+          litellm_params:
+            model: gemini/gemini-2.5-flash
+            api_key: os.environ/GEMINI_API_KEY
+        # Gemini image generation models
+        - model_name: gemini-3.1-flash-image
+          model_info:
+            mode: image_generation
+          litellm_params:
+            model: gemini/gemini-3.1-flash-image
+            api_key: os.environ/GEMINI_API_KEY
+        - model_name: gemini-3.1-flash-lite-image
+          model_info:
+            mode: image_generation
+          litellm_params:
+            model: gemini/gemini-3.1-flash-lite-image
+            api_key: os.environ/GEMINI_API_KEY
+        # Ollama Cloud models (https://ollama.com)
+        - model_name: ollama-glm-5.1
+          litellm_params:
+            model: ollama_chat/glm-5.1
+            api_base: https://ollama.com
+            api_key: os.environ/OLLAMA_API_KEY
+        - model_name: ollama-deepseek-v4-pro
+          litellm_params:
+            model: ollama_chat/deepseek-v4-pro
+            api_base: https://ollama.com
+            api_key: os.environ/OLLAMA_API_KEY
+        - model_name: ollama-kimi-k2.6
+          litellm_params:
+            model: ollama_chat/kimi-k2.6
+            api_base: https://ollama.com
+            api_key: os.environ/OLLAMA_API_KEY
+        - model_name: ollama-gemma4-31b
+          litellm_params:
+            model: ollama_chat/gemma4:31b
+            api_base: https://ollama.com
+            api_key: os.environ/OLLAMA_API_KEY
+        - model_name: ollama-qwen3.5
+          litellm_params:
+            model: ollama_chat/qwen3.5
+            api_base: https://ollama.com
+            api_key: os.environ/OLLAMA_API_KEY
+        - model_name: ollama-minimax-m3
+          litellm_params:
+            model: ollama_chat/minimax-m3
+            api_base: https://ollama.com
+            api_key: os.environ/OLLAMA_API_KEY
+        - model_name: ollama-deepseek-v4-flash
+          litellm_params:
+            model: ollama_chat/deepseek-v4-flash
+            api_base: https://ollama.com
+            api_key: os.environ/OLLAMA_API_KEY
+        - model_name: ollama-glm-5.2
+          litellm_params:
+            model: ollama_chat/glm-5.2
+            api_base: https://ollama.com
+            api_key: os.environ/OLLAMA_API_KEY
+        # OpenCode Go models (https://opencode.ai/docs/go/) — OpenAI-compatible endpoint
+        - model_name: opencode-go-glm-5.1
+          litellm_params:
+            model: openai/glm-5.1
+            api_base: https://opencode.ai/zen/go/v1
+            api_key: os.environ/OPENCODE_API_KEY
+        - model_name: opencode-go-deepseek-v4-pro
+          litellm_params:
+            model: openai/deepseek-v4-pro
+            api_base: https://opencode.ai/zen/go/v1
+            api_key: os.environ/OPENCODE_API_KEY
+        - model_name: opencode-go-kimi-k2.6
+          litellm_params:
+            model: openai/kimi-k2.6
+            api_base: https://opencode.ai/zen/go/v1
+            api_key: os.environ/OPENCODE_API_KEY
+        - model_name: opencode-go-deepseek-v4-flash
+          litellm_params:
+            model: openai/deepseek-v4-flash
+            api_base: https://opencode.ai/zen/go/v1
+            api_key: os.environ/OPENCODE_API_KEY
+        - model_name: opencode-go-glm-5.2
+          litellm_params:
+            model: openai/glm-5.2
+            api_base: https://opencode.ai/zen/go/v1
+            api_key: os.environ/OPENCODE_API_KEY
+        # OpenCode Go models — Anthropic-native endpoint
+        - model_name: opencode-go-minimax-m3
+          litellm_params:
+            model: anthropic/minimax-m3
+            api_base: https://opencode.ai/zen/go
+            api_key: os.environ/OPENCODE_API_KEY
+        - model_name: opencode-go-qwen3.7-max
+          litellm_params:
+            model: anthropic/qwen3.7-max
+            api_base: https://opencode.ai/zen/go
+            api_key: os.environ/OPENCODE_API_KEY
+        - model_name: opencode-go-qwen3.7-plus
+          litellm_params:
+            model: anthropic/qwen3.7-plus
+            api_base: https://opencode.ai/zen/go
+            api_key: os.environ/OPENCODE_API_KEY
+        # GitHub Copilot models (OAuth device flow — tokens persisted in PVC)
+        - model_name: github-copilot-sonnet-5
+          litellm_params:
+            model: github_copilot/sonnet-5
+        - model_name: github-copilot-gemini-3.5-flash
+          litellm_params:
+            model: github_copilot/gemini-3.5-flash
+        - model_name: github-copilot-gpt-5.4
+          litellm_params:
+            model: github_copilot/gpt-5.4
+        - model_name: github-copilot-gpt-5.4-mini
+          litellm_params:
+            model: github_copilot/gpt-5.4-mini
+
+      litellm_settings:
+        drop_params: true
+        request_timeout: 600
+        num_retries: 2
+        set_verbose: false
+        json_logs: true
+        cache: true
+        cache_params:
+          type: redis
+          host: os.environ/REDIS_HOST
+          port: os.environ/REDIS_PORT
+          password: os.environ/REDIS_PASSWORD
+
+      general_settings:
+        master_key: os.environ/PROXY_MASTER_KEY
+        database_url: os.environ/DATABASE_URL
+        store_model_in_db: true
+        # Production best practices (https://docs.litellm.ai/docs/proxy/prod)
+        proxy_batch_write_at: 60
+        database_connection_pool_limit: 10
+        disable_error_logs: true
+
+    # Persistent storage for GitHub Copilot OAuth tokens
+    volumes:
+      - name: github-copilot-tokens
+        persistentVolumeClaim:
+          claimName: litellm-github-copilot-tokens
+    volumeMounts:
+      - name: github-copilot-tokens
+        mountPath: /data/github_copilot
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 512Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -242,6 +242,6 @@ spec:
     resources:
       requests:
         cpu: 50m
-        memory: 512Mi
+        memory: &memory 1Gi
       limits:
-        memory: 1Gi
+        memory: *memory

--- a/kubernetes/apps/base/litellm/httproute.yaml
+++ b/kubernetes/apps/base/litellm/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: litellm
+  namespace: litellm
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: envoy
+  hostnames:
+    - litellm.${INTERNAL_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: litellm
+          port: 4000

--- a/kubernetes/apps/base/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/litellm/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: &app litellm
+
+labels:
+  - pairs:
+      app.kubernetes.io/module: *app
+
+resources:
+  - namespace.yaml
+  - store.yaml
+  - pgcluster.yaml
+  - network.yaml
+  - secrets.yaml
+  - dragonfly.yaml
+  - pvc.yaml
+  - httproute.yaml
+  - helm.yaml

--- a/kubernetes/apps/base/litellm/namespace.yaml
+++ b/kubernetes/apps/base/litellm/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: litellm

--- a/kubernetes/apps/base/litellm/network.yaml
+++ b/kubernetes/apps/base/litellm/network.yaml
@@ -1,0 +1,105 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-all-except-namespace
+  namespace: litellm
+spec:
+  description: "Allow traffic only to the namespace itself"
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": litellm
+  ingress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cnpg-cluster
+  namespace: litellm
+spec:
+  description: "Allow CloudNativePG pods access"
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: litellm-cluster
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: litellm
+            cnpg.io/cluster: litellm-cluster
+      toPorts:
+        - ports:
+            - port: postgresql
+              protocol: TCP
+            - port: status
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: litellm
+            app.kubernetes.io/name: litellm
+      toPorts:
+        - ports:
+            - port: postgresql
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dragonfly
+  namespace: litellm
+spec:
+  description: "Allow Dragonfly pods access"
+  endpointSelector:
+    matchLabels:
+      app: litellm-dragonfly
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: litellm
+            app.kubernetes.io/name: litellm
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: litellm-server
+  namespace: litellm
+spec:
+  description: "Allow traffic from and to litellm server"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: litellm
+      app.kubernetes.io/instance: litellm
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": envoy
+            app.kubernetes.io/name: envoy
+      toPorts:
+        - ports:
+            - port: "4000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": pangolin
+            app.kubernetes.io/name: pangolin
+            app.kubernetes.io/component: newt
+      toPorts:
+        - ports:
+            - port: "4000"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: netbird
+            app.kubernetes.io/name: netbird-router
+      toPorts:
+        - ports:
+            - port: "4000"
+              protocol: TCP
+  egress:
+    - toEntities:
+        - world
+

--- a/kubernetes/apps/base/litellm/pgcluster.yaml
+++ b/kubernetes/apps/base/litellm/pgcluster.yaml
@@ -1,0 +1,68 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: litellm-cluster
+  namespace: litellm
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: "disabled"
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3-standard-trixie
+  instances: 2
+  primaryUpdateStrategy: unsupervised
+  affinity:
+    podAntiAffinityType: required
+  storage:
+    storageClass: ceph-block
+    size: 5Gi
+
+  bootstrap:
+    recovery:
+      source: backup
+      database: litellm
+      owner: litellm
+      secret:
+        name: litellm-cluster-credentials
+    # initdb:
+    #   database: litellm
+    #   owner: litellm
+    #   secret:
+    #     name: litellm-cluster-credentials
+
+  externalClusters:
+    - name: backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: backup-store
+          serverName: litellm-cluster
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: backup-store
+        serverName: litellm-cluster
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: &memory 384Mi
+    limits:
+      memory: *memory
+
+  monitoring:
+    enablePodMonitor: true
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: litellm-cluster-backup
+  namespace: litellm
+spec:
+  cluster:
+    name: litellm-cluster
+  schedule: "0 0 0 * * *"
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/base/litellm/pvc.yaml
+++ b/kubernetes/apps/base/litellm/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: litellm-github-copilot-tokens
+  namespace: litellm
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ceph-filesystem
+  resources:
+    requests:
+      storage: 100Mi

--- a/kubernetes/apps/base/litellm/secrets.yaml
+++ b/kubernetes/apps/base/litellm/secrets.yaml
@@ -1,0 +1,130 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-postgres
+  namespace: litellm
+spec:
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: litellm-cluster-credentials
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: /litellm/POSTGRES_USERNAME
+    - secretKey: password
+      remoteRef:
+        key: /litellm/POSTGRES_PASSWORD
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-backup-s3-account
+  namespace: litellm
+spec:
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: litellm-backup-s3-account
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ACCESS_KEY: "{{ .access_key }}"
+        SECRET_KEY: "{{ .secret_key }}"
+  data:
+    - secretKey: access_key
+      remoteRef:
+        key: /litellm/BACKUP_S3_ACCESS_KEY
+    - secretKey: secret_key
+      remoteRef:
+        key: /litellm/BACKUP_S3_SECRET_KEY
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-dragonfly
+  namespace: litellm
+spec:
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: litellm-dragonfly-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: DRAGONFLY_PASSWORD
+      remoteRef:
+        key: /litellm/DRAGONFLY_PASSWORD
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-secret-env
+  namespace: litellm
+spec:
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: litellm-secret-env
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        PROXY_MASTER_KEY: "{{ .master_key }}"
+        OPENAI_API_KEY: "{{ .openai_api_key }}"
+        ANTHROPIC_API_KEY: "{{ .anthropic_api_key }}"
+        GEMINI_API_KEY: "{{ .gemini_api_key }}"
+        OLLAMA_API_KEY: "{{ .ollama_api_key }}"
+        OPENCODE_API_KEY: "{{ .opencode_api_key }}"
+        GITHUB_COPILOT_TOKEN_DIR: /data/github_copilot
+        REDIS_HOST: litellm-dragonfly
+        REDIS_PORT: "6379"
+        REDIS_PASSWORD: "{{ .redis_password }}"
+        # SSO (Authentik OIDC)
+        GENERIC_CLIENT_ID: "{{ .sso_client_id }}"
+        GENERIC_CLIENT_SECRET: "{{ .sso_client_secret }}"
+        GENERIC_AUTHORIZATION_ENDPOINT: https://authentik.${EXTERNAL_DOMAIN}/application/o/litellm/authorize/
+        GENERIC_TOKEN_ENDPOINT: https://authentik.${EXTERNAL_DOMAIN}/application/o/litellm/token/
+        GENERIC_USERINFO_ENDPOINT: https://authentik.${EXTERNAL_DOMAIN}/application/o/litellm/userinfo/
+        GENERIC_SCOPE: openid profile email litellm_role
+        GENERIC_USER_ROLE_ATTRIBUTE: litellm_role
+        PROXY_BASE_URL: https://litellm.${INTERNAL_DOMAIN}
+        PROXY_LOGOUT_URL: https://authentik.${EXTERNAL_DOMAIN}/application/o/litellm/end-session/
+        AUTO_REDIRECT_UI_LOGIN_TO_SSO: "true"
+  data:
+    - secretKey: master_key
+      remoteRef:
+        key: /litellm/MASTER_KEY
+    - secretKey: openai_api_key
+      remoteRef:
+        key: /litellm/OPENAI_API_KEY
+    - secretKey: anthropic_api_key
+      remoteRef:
+        key: /litellm/ANTHROPIC_API_KEY
+    - secretKey: gemini_api_key
+      remoteRef:
+        key: /litellm/GEMINI_API_KEY
+    - secretKey: ollama_api_key
+      remoteRef:
+        key: /litellm/OLLAMA_API_KEY
+    - secretKey: opencode_api_key
+      remoteRef:
+        key: /litellm/OPENCODE_API_KEY
+    - secretKey: client_id
+      remoteRef:
+        key: /litellm/OIDC_CLIENT_ID
+    - secretKey: client_secret
+      remoteRef:
+        key: /litellm/OIDC_CLIENT_SECRET
+    - secretKey: redis_password
+      remoteRef:
+        key: /litellm/DRAGONFLY_PASSWORD

--- a/kubernetes/apps/base/litellm/secrets.yaml
+++ b/kubernetes/apps/base/litellm/secrets.yaml
@@ -85,6 +85,7 @@ spec:
         GEMINI_API_KEY: "{{ .gemini_api_key }}"
         OLLAMA_API_KEY: "{{ .ollama_api_key }}"
         OPENCODE_API_KEY: "{{ .opencode_api_key }}"
+        DEEPGRAM_API_KEY: "{{ .deepgram_api_key }}"
         GITHUB_COPILOT_TOKEN_DIR: /data/github_copilot
         REDIS_HOST: litellm-dragonfly
         REDIS_PORT: "6379"
@@ -128,3 +129,7 @@ spec:
     - secretKey: redis_password
       remoteRef:
         key: /litellm/DRAGONFLY_PASSWORD
+    - secretKey: deepgram_api_key
+      remoteRef:
+      key: /litellm/DEEPGRAM_API_KEY
+

--- a/kubernetes/apps/base/litellm/store.yaml
+++ b/kubernetes/apps/base/litellm/store.yaml
@@ -1,0 +1,21 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: backup-store
+  namespace: litellm
+spec:
+  configuration:
+    destinationPath: s3://litellm
+    endpointURL: https://truenas.${INTERNAL_DOMAIN}:30292
+    s3Credentials:
+      accessKeyId:
+        name: litellm-backup-s3-account
+        key: ACCESS_KEY
+      secretAccessKey:
+        name: litellm-backup-s3-account
+        key: SECRET_KEY
+    wal:
+      compression: gzip
+    data:
+      compression: gzip
+  retentionPolicy: "7d"

--- a/kubernetes/apps/overlays/dev/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   # - harbor
   # - immich
   # - joplin
+  - litellm
   # - n8n
   # - netbox
   - openwebui

--- a/kubernetes/apps/overlays/dev/litellm/bucket.yaml
+++ b/kubernetes/apps/overlays/dev/litellm/bucket.yaml
@@ -1,0 +1,10 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: litellm-cluster-bucket
+  namespace: litellm
+spec:
+  bucketName: litellm-cluster
+  storageClassName: ceph-bucket
+  additionalConfig:
+    maxSize: 1G

--- a/kubernetes/apps/overlays/dev/litellm/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/litellm/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: litellm
+
+labels:
+  - pairs:
+      app.kubernetes.io/module: litellm
+
+resources:
+  - ../../../base/litellm
+  - bucket.yaml
+
+patches:
+  - path: store.yaml
+    target:
+      kind: ObjectStore
+  - path: pgcluster.yaml
+    target:
+      kind: Cluster
+  - patch: |-
+      - op: replace
+        path: /spec/values/replicaCount
+        value: 1
+    target:
+      kind: HelmRelease
+      name: litellm

--- a/kubernetes/apps/overlays/dev/litellm/pgcluster.yaml
+++ b/kubernetes/apps/overlays/dev/litellm/pgcluster.yaml
@@ -1,0 +1,22 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: litellm-cluster
+  namespace: litellm
+  annotations:
+    cnpg.io/skipEmptyWalArchiveCheck: "disabled"
+spec:
+  bootstrap:
+    recovery: null
+    initdb:
+      database: litellm
+      owner: litellm
+      secret:
+        name: litellm-cluster-credentials
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: backup-store
+        serverName: litellm-cluster

--- a/kubernetes/apps/overlays/dev/litellm/store.yaml
+++ b/kubernetes/apps/overlays/dev/litellm/store.yaml
@@ -1,0 +1,16 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: backup-store
+  namespace: litellm
+spec:
+  configuration:
+    destinationPath: s3://litellm-cluster
+    endpointURL: http://rook-ceph-rgw-ceph-objectstore.rook-ceph.svc.cluster.local
+    s3Credentials:
+      accessKeyId:
+        name: litellm-cluster-bucket
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: litellm-cluster-bucket
+        key: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/apps/overlays/prd/kustomization.yaml
+++ b/kubernetes/apps/overlays/prd/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ../../base/harbor
   - ../../base/immich
   - ../../base/joplin
+  - ../../base/litellm
   - ../../base/n8n
   - ../../base/netbox
   - ../../base/openwebui


### PR DESCRIPTION
## Summary

Adds [LiteLLM](https://github.com/BerriAI/litellm) as a unified AI gateway, routing OpenAI-compatible requests to multiple providers through a single endpoint.

## Stack

- **PostgreSQL** — CloudNativePG cluster for virtual keys, usage tracking, budgets
- **Redis** — Dragonfly for response caching
- **Ingress** — Envoy Gateway HTTPRoute + Netbird VPN (service exposed via `netbird.io/expose` annotation)
- **Auth** — Authentik OIDC SSO for admin UI
- **Metrics** — Prometheus ServiceMonitor
- **Backups** — Daily Barman snapshots to TrueNAS S3

## Providers

| Provider | Models |
|---|---|
| OpenAI (chat) | — |
| OpenAI (image) | gpt-image-2 |
| OpenAI (audio) | tts, whisper |
| Anthropic | claude-fable-5, claude-sonnet-5, claude-opus-4.8 |
| Gemini (image) | gemini-3.1-flash-image, gemini-3.1-flash-lite-image |
| Ollama Cloud | glm-5.1/5.2, kimi-k2.6, deepseek-v4-pro/flash, gemma4:31b, qwen3.5, minimax-m3 |
| OpenCode Go | glm-5.1/5.2, kimi-k2.6, deepseek-v4-pro/flash, minimax-m3, qwen3.7-max/plus |
| GitHub Copilot | sonnet-5, gemini-3.5-flash, gpt-5.4, gpt-5.4-mini |
| Deepgram | nova-2 |

GitHub Copilot requires an interactive OAuth device flow on first use; tokens are persisted in a `ReadWriteMany` CephFS PVC so both replicas can share them.

## Required Infisical secrets

Under `/litellm/`:
- `MASTER_KEY`
- `POSTGRES_USERNAME`, `POSTGRES_PASSWORD`
- `DRAGONFLY_PASSWORD`
- `BACKUP_S3_ACCESS_KEY`, `BACKUP_S3_SECRET_KEY`
- `OPENAI_API_KEY`
- `ANTHROPIC_API_KEY`
- `GEMINI_API_KEY`
- `OLLAMA_API_KEY`
- `OPENCODE_API_KEY`
- `DEEPGRAM_API_KEY`
- `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` (Authentik OIDC)

## Authentik setup

1. Create scope mapping `litellm_role` → `{"litellm_role": "proxy_admin"}`
2. Create OAuth2/OIDC provider with redirect URI `https://litellm.<internal-domain>/sso/callback`, scopes `openid profile email litellm_role`
3. Create application linked to the provider