### PR TITLE
feat(openwebui,litellm): track per-user usage from Open WebUI

### DIFF
--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -243,6 +243,12 @@ spec:
         master_key: os.environ/PROXY_MASTER_KEY
         database_url: os.environ/DATABASE_URL
         store_model_in_db: true
+        # Per-user usage tracking from Open WebUI
+        user_header_mappings:
+          - header_name: X-OpenWebUI-User-Id
+            litellm_user_role: internal_user
+          - header_name: X-OpenWebUI-User-Email
+            litellm_user_role: customer
         # Production best practices (https://docs.litellm.ai/docs/proxy/prod)
         proxy_batch_write_at: 60
         database_connection_pool_limit: 10

--- a/kubernetes/apps/base/openwebui/helm.yaml
+++ b/kubernetes/apps/base/openwebui/helm.yaml
@@ -72,6 +72,10 @@ spec:
               - name: ENABLE_LOGIN_FORM
                 value: "false"
 
+              # Forward user info to LiteLLM for per-user usage tracking
+              - name: ENABLE_FORWARD_USER_INFO_HEADERS
+                value: "true"
+
               # TTS
               - name: AUDIO_TTS_OPENAI_API_BASE_URL
                 value: https://api.openai.com/v1


### PR DESCRIPTION
## Summary

Forwards per-user identity from Open WebUI to LiteLLM so spend is attributed per user.

## Changes

- **openwebui** — set `ENABLE_FORWARD_USER_INFO_HEADERS=true` so Open WebUI adds `X-OpenWebUI-User-Id`, `X-OpenWebUI-User-Email`, `X-OpenWebUI-User-Name` headers to upstream requests
- **litellm** — add `user_header_mappings` to `general_settings`:
  - `X-OpenWebUI-User-Id` → `internal_user` (tracked in `LiteLLM_UserTable`)
  - `X-OpenWebUI-User-Email` → `customer` (tracked in `LiteLLM_CustomerTable`, fallback if no ID)

## Behavior

Open WebUI always sends the user ID header for authenticated users, so in practice every authenticated user is tracked as an `internal_user` (via `X-OpenWebUI-User-Id`). The email mapping is a fallback for cases where only the email is present (e.g. untrusted / unauthenticated contexts).

To track only certain users as `internal_user` and the rest as `customer`, Open WebUI would need to forward different headers per user role — it doesn't currently support that.