### PR TITLE
feat(paperless): add Tika + Gotenberg for Office document consumption

### DIFF
--- a/kubernetes/apps/base/paperless/helm.yaml
+++ b/kubernetes/apps/base/paperless/helm.yaml
@@ -64,6 +64,10 @@ spec:
               PAPERLESS_REDIRECT_LOGIN_TO_SSO: true
               S6_READ_ONLY_ROOT: 1
               S6_YES_I_WANT_A_WORLD_WRITABLE_RUN_BECAUSE_KUBERNETES: 1
+              # Content extraction: global Tika (shared utility) + in-namespace Gotenberg for Office→PDF conversion.
+              PAPERLESS_TIKA_ENABLED: 1
+              PAPERLESS_TIKA_ENDPOINT: http://tika.tika.svc.cluster.local
+              PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://paperless-gotenberg.paperless.svc.cluster.local:3000
             envFrom:
               - secretRef:
                   name: paperless-secret-env
@@ -119,6 +123,81 @@ spec:
             seccompProfile:
               type: RuntimeDefault
 
+      # Gotenberg — document conversion (Office/HTML → PDF) for Paperless consume.
+      # Deployed alongside Paperless only (not shared); Tika is the global shared instance.
+      gotenberg:
+        type: deployment
+        strategy: RollingUpdate
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          gotenberg:
+            image:
+              repository: docker.io/gotenberg/gotenberg
+              tag: 8.33@sha256:bddd8ea9d076e2d08b6ddaa6efae6403185202c6dab65a6488ed0a6923d6d8e8
+            # Hardened chromium per upstream paperless compose: disable JS and restrict to local
+            # file:// URLs so .eml conversion can't fetch tracking pixels or run external scripts.
+            args:
+              - gotenberg
+              - --chromium-disable-javascript=true
+              - --chromium-allow-list=file:///tmp/.*
+            ports:
+              - containerPort: 3000
+                name: http
+                protocol: TCP
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: http
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: http
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: http
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+        pod:
+          # gotenberg image runs as non-root user `gotenberg` (UID 1001) by default.
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+
     service:
       main:
         annotations:
@@ -127,6 +206,12 @@ spec:
         ports:
           http:
             port: 80
+            targetPort: http
+      gotenberg:
+        controller: gotenberg
+        ports:
+          http:
+            port: 3000
             targetPort: http
 
     route:
@@ -176,3 +261,23 @@ spec:
             subPath: tmp
           - path: /run
             subPath: run
+
+      # ===== Gotenberg writable paths (readOnlyRootFilesystem) =====
+      gotenberg-tmp:
+        type: emptyDir
+        advancedMounts:
+          gotenberg:
+            gotenberg:
+              - path: /tmp
+      gotenberg-var-tmp:
+        type: emptyDir
+        advancedMounts:
+          gotenberg:
+            gotenberg:
+              - path: /var/tmp
+      gotenberg-home:
+        type: emptyDir
+        advancedMounts:
+          gotenberg:
+            gotenberg:
+              - path: /home/gotenberg

--- a/kubernetes/apps/base/paperless/helm.yaml
+++ b/kubernetes/apps/base/paperless/helm.yaml
@@ -67,7 +67,7 @@ spec:
               # Content extraction: global Tika (shared utility) + in-namespace Gotenberg for Office→PDF conversion.
               PAPERLESS_TIKA_ENABLED: 1
               PAPERLESS_TIKA_ENDPOINT: http://tika.tika.svc.cluster.local
-              PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://paperless-gotenberg.paperless.svc.cluster.local:3000
+              PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://paperless-gotenberg.paperless.svc.cluster.local
             envFrom:
               - secretRef:
                   name: paperless-secret-env
@@ -211,7 +211,9 @@ spec:
         controller: gotenberg
         ports:
           http:
-            port: 3000
+            # Service on port 80 (maps to the container's native 3000) so Paperless
+            # can use the bare URL http://paperless-gotenberg.paperless.svc.cluster.local
+            port: 80
             targetPort: http
 
     route:

--- a/kubernetes/apps/base/paperless/helm.yaml
+++ b/kubernetes/apps/base/paperless/helm.yaml
@@ -27,6 +27,9 @@ spec:
   values:
     controllers:
       main:
+        # With >1 controller the chart appends the controller identifier to resource names
+        # (paperless-main). Force the original name to preserve deploy/paperless + svc/paperless.
+        forceRename: paperless
         labels:
           nfsMount: "true"
         annotations:
@@ -200,6 +203,8 @@ spec:
 
     service:
       main:
+        # Keep the service name as `paperless` (not `paperless-main`) for compatibility.
+        forceRename: paperless
         annotations:
           netbird.io/expose: "true"
         controller: main

--- a/kubernetes/apps/base/paperless/network.yaml
+++ b/kubernetes/apps/base/paperless/network.yaml
@@ -151,15 +151,4 @@ spec:
         - ports:
             - port: http
               protocol: TCP
-  egress:
-    # Gotenberg is stateless; only DNS lookups (none needed in practice, but allow kube-dns).
-    - toEndpoints:
-        - matchLabels:
-            "k8s:io.kubernetes.pod.namespace": kube-system
-            "k8s:k8s-app": kube-dns
-      toPorts:
-        - ports:
-            - port: "53"
-              protocol: UDP
-            - port: "53"
-              protocol: TCP
+  egress: []

--- a/kubernetes/apps/base/paperless/network.yaml
+++ b/kubernetes/apps/base/paperless/network.yaml
@@ -143,13 +143,13 @@ spec:
     # Only the Paperless main pod may call Gotenberg
     - fromEndpoints:
         - matchLabels:
-            "k8s:io.kubernetes.pod.namespace": paperless
+            io.kubernetes.pod.namespace: paperless
             app.kubernetes.io/name: paperless
             app.kubernetes.io/instance: paperless
             app.kubernetes.io/controller: main
       toPorts:
         - ports:
-            - port: "3000"
+            - port: http
               protocol: TCP
   egress:
     # Gotenberg is stateless; only DNS lookups (none needed in practice, but allow kube-dns).

--- a/kubernetes/apps/base/paperless/network.yaml
+++ b/kubernetes/apps/base/paperless/network.yaml
@@ -67,6 +67,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: paperless
       app.kubernetes.io/instance: paperless
+      app.kubernetes.io/controller: main
   ingress:
     - fromEndpoints:
         - matchLabels:
@@ -114,5 +115,51 @@ spec:
         - ports:
             - port: smtp
               protocol: TCP
+    # Global Tika content-extraction service (cross-namespace shared utility)
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: tika
+            app.kubernetes.io/name: tika
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
     - toEntities:
         - world
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gotenberg
+  namespace: paperless
+spec:
+  description: "Allow Paperless consume to reach Gotenberg (in-namespace); Gotenberg has no outbound needs"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: paperless
+      app.kubernetes.io/instance: paperless
+      app.kubernetes.io/controller: gotenberg
+  ingress:
+    # Only the Paperless main pod may call Gotenberg
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": paperless
+            app.kubernetes.io/name: paperless
+            app.kubernetes.io/instance: paperless
+            app.kubernetes.io/controller: main
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP
+  egress:
+    # Gotenberg is stateless; only DNS lookups (none needed in practice, but allow kube-dns).
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP


### PR DESCRIPTION
## Summary

Wire Paperless to use the **global shared Tika instance** for content extraction and add a **hardened in-namespace Gotenberg sidecar** for Office/HTML→PDF conversion — matching the [upstream `docker-compose.postgres-tika.yml`](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docker/compose/docker-compose.postgres-tika.yml) pattern.

## Changes

### Paperless env (content extraction)
- `PAPERLESS_TIKA_ENABLED: 1`
- `PAPERLESS_TIKA_ENDPOINT: http://tika.tika.svc.cluster.local` — the **global** Tika utility (port 80, deployed in PR #419), not a per-app sidecar
- `PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://paperless-gotenberg.paperless.svc.cluster.local:3000` — in-namespace Gotenberg

### Gotenberg (new `gotenberg` controller, in-namespace only)
- `gotenberg/gotenberg:8.33` with the hardened chromium flags from the upstream compose:
  - `--chromium-disable-javascript=true` — no JS execution during .eml conversion
  - `--chromium-allow-list=file:///tmp/.*` — chromium can only load local files, no tracking pixels / external content
- **Container hardening**: non-root (UID 1001, image native), `readOnlyRootFilesystem: true`, `capabilities: drop ALL`, `allowPrivilegeEscalation: false`, `seccompProfile: RuntimeDefault`
- emptyDir mounts for `/tmp`, `/var/tmp`, `/home/gotenberg` (the writable paths the image needs under a read-only rootfs)
- liveness/readiness/startup probes on `/health`; 512Mi → 1Gi memory; 1 replica
- **Verified locally**: the image starts under `--read-only --cap-drop=ALL --security-opt no-new-privileges` + non-root, `/health` returns 200, and a real LibreOffice text→PDF conversion returns a valid `%PDF` document.

### Network hardening (`network.yaml`)
- **`paperless-server` CNP**: scoped its `endpointSelector` to `app.kubernetes.io/controller: main` (previously matched `name+instance`, which the chart sets on **both** the main and gotenberg pods — so gotenberg would have inherited world egress). Added egress to the global `tika` namespace on port 80.
- **New `gotenberg` CNP**: ingress only from the Paperless main pod (`controller: main`) on port 3000; egress only to kube-dns. Gotenberg is stateless with no world egress.

## Notes

- **Tika is not redeployed here** — it is the global shared utility established in PR #419 (`kubernetes/apps/base/tika/`). The Tika-side CiliumNetworkPolicy in that PR already allows ingress from the `paperless` namespace on port 80, so no Tika-side change is needed.
- The label `app.kubernetes.io/controller` (not `component`) is what the bjw-s app-template chart uses to distinguish controllers — confirmed against the immich chart's CNP conventions.
- Paperless's own `main` container security context is unchanged (it still runs as root to install OCR packages at startup — a pre-existing `TODO` in the file to build a custom image). Gotenberg is fully hardened; the main container keeps its existing dropped-caps + added set.

## Testing
After merge + Flux reconcile:
```bash
# Gotenberg health
kubectl exec -n paperless deploy/paperless-main -- \
  curl -s http://paperless-gotenberg.paperless.svc.cluster.local:3000/health

# Tika reachable from paperless
kubectl exec -n paperless deploy/paperless-main -- \
  curl -s -X PUT -H "Accept: text/plain" --data-binary @/etc/hostname \
  http://tika.tika.svc.cluster.local/tika

# Then upload an Office doc (.docx/.xlsx/.eml) to Paperless consume and confirm it ingests
```