### PR TITLE
fix(openwebui): disable OIDC in dev overlay

### DIFF
--- a/kubernetes/apps/overlays/dev/openwebui/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/openwebui/kustomization.yaml
@@ -19,23 +19,6 @@ patches:
     target:
       kind: Cluster
   - patch: |-
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/4
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/5
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/6
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/7
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/8
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/9
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/10
-    target:
-      kind: HelmRelease
-  - patch: |-
       - op: replace
         path: /spec/jobTemplate/spec/template/spec/containers/0/env/3/value
         value: test
@@ -51,3 +34,16 @@ patches:
     target:
       kind: CiliumNetworkPolicy
       name: openwebui-sync
+  - patch: |-
+      # Disable OIDC and use built-in username/password auth in dev.
+      # env index 8 = ENABLE_OAUTH_SIGNUP, index 9 = ENABLE_LOGIN_FORM
+      # (see kubernetes/apps/base/openwebui/helm.yaml)
+      - op: replace
+        path: /spec/values/controllers/main/containers/main/env/8/value
+        value: "false"
+      - op: replace
+        path: /spec/values/controllers/main/containers/main/env/9/value
+        value: "true"
+    target:
+      kind: HelmRelease
+      name: openwebui


### PR DESCRIPTION
## Summary

Switches the dev overlay of Open WebUI from Authentik OIDC to the built-in username/password login.

- Flips `ENABLE_OAUTH_SIGNUP` to `false` (disables OAuth login/signup)
- Flips `ENABLE_LOGIN_FORM` to `true` (enables built-in username/password auth)

via a JSON6902 patch on the `openwebui` HelmRelease in `kubernetes/apps/overlays/dev/openwebui/kustomization.yaml`, matching the existing overlay patch style. Production (`prd`) is unaffected — it continues to inherit the base (OIDC via Authentik).

## Notes

- The other OIDC env vars (`OPENID_PROVIDER_URL`, `OPENID_REDIRECT_URI`, `OAUTH_SCOPES`, `OAUTH_PROVIDER_NAME`, `OAUTH_MERGE_ACCOUNTS_BY_EMAIL`) remain in the rendered output but are inert while `ENABLE_OAUTH_SIGNUP=false`. Leaving them avoids a separate dev secrets template and keeps the overlay minimal.
- `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` are still synced from Infisical into `openwebui-secret-env` but go unused in dev. Harmless; a follow-up could trim these if desired.
- Patch uses positional env indices (`env/8`, `env/9`), consistent with the existing CronJob and CiliumNetworkPolicy patches in the same file. Indices are documented in a comment referencing the base `helm.yaml`.