### PR TITLE
feat(kubernetes): add toolhive operator and MCP servers

### DIFF
--- a/.renovate/groups.json
+++ b/.renovate/groups.json
@@ -82,7 +82,17 @@
       "description": "Ceph Group",
       "groupName": "Ceph",
       "matchDatasources": ["helm"],
-      "matchPackageNames": ["/rook-ceph/", "/rook-ceph-cluster/"],
+      "matchPackageNames": ["/rook-ceph/"],
+      "group": {
+        "commitMessageTopic": "{{{groupName}}} group"
+      },
+      "minimumGroupSize": 2
+    },
+    {
+      "description": "Toolhive group",
+      "groupName": "Toolhive",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["/toolhive-operator/"],
       "group": {
         "commitMessageTopic": "{{{groupName}}} group"
       },

--- a/.taskfiles/kubernetes/Taskfile.yaml
+++ b/.taskfiles/kubernetes/Taskfile.yaml
@@ -49,7 +49,7 @@ tasks:
       CPUS: "{{.CPUS | default 4}}"
       MEMORY: '{{.MEMORY | default "8G"}}'
     cmds:
-      - minikube start --driver kvm2 --disk-size 40G --extra-disks 1 --cni cilium --nodes {{.NODES}} --cpus {{.CPUS}} --memory {{.MEMORY}} --addons metrics-server --addons storage-provisioner-rancher --addons metallb --kvm-network minikube
+      - minikube start --driver kvm2 --disk-size 40G --extra-disks 1 --cni cilium --nodes {{.NODES}} --cpus {{.CPUS}} --memory {{.MEMORY}} --addons metrics-server --addons storage-provisioner-rancher --addons metallb
       - minikube addons configure metallb
     preconditions:
       - sh: which minikube

--- a/flake.lock
+++ b/flake.lock
@@ -49,10 +49,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1783703440,
+        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-stable": "nixpkgs-stable"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,11 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-26.05";
   };
 
   outputs =
-    inputs@{ flake-parts, ... }:
+    inputs@{ flake-parts, nixpkgs-stable, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         # To import a flake module
@@ -24,9 +25,6 @@
       ];
       perSystem =
         {
-          config,
-          self',
-          inputs',
           pkgs,
           system,
           ...
@@ -51,8 +49,17 @@
               yq-go
               gitleaks
               pre-commit
-              (minikube.override { withQemu = true; })
-              vault
+              # Sourced from nixos-26.05 stable, not nixos-unstable.
+              # nixos-unstable's minikube fetches its source by tag, so
+              # `src.rev` resolves to `refs/tags/v1.38.1`. That string
+              # contains forward slashes, which Kubernetes rejects as a node
+              # label value, so multi-node clusters fail at the first worker
+              # join with `GUEST_START: invalid label value:
+              # minikube.k8s.io/commit=refs/tags/v1.38.1`.
+              # nixos-26.05 fetches by rev instead, so `src.rev` is `v1.38.1`
+              # (a valid label). Both channels ship minikube 1.38.1.
+              # See DECISION.md for details.
+              (nixpkgs-stable.legacyPackages.${system}.minikube.override { withQemu = true; })
               awscli2
               infisical
             ];

--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -790,6 +790,12 @@ spec:
             - read:packages
             - read:org
           allow_all_keys: true
+        playwright:
+          url: http://mcp-playwright-proxy.toolhive.svc.cluster.local:8080/mcp
+          auth_type: none
+        searxng:
+          url: http://mcp-searxng-proxy.toolhive.svc.cluster.local:8080/mcp
+          auth_type: none
 
     # Persistent storage for GitHub Copilot OAuth tokens
     volumes:

--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -790,8 +790,8 @@ spec:
             - read:packages
             - read:org
           allow_all_keys: true
-        playwright:
-          url: http://mcp-playwright-proxy.toolhive.svc.cluster.local:8080/mcp
+        terraform:
+          url: http://mcp-terraform-proxy.toolhive.svc.cluster.local:8080/mcp
           auth_type: none
           allow_all_keys: true
         searxng:

--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -793,9 +793,11 @@ spec:
         playwright:
           url: http://mcp-playwright-proxy.toolhive.svc.cluster.local:8080/mcp
           auth_type: none
+          allow_all_keys: true
         searxng:
           url: http://mcp-searxng-proxy.toolhive.svc.cluster.local:8080/mcp
           auth_type: none
+          allow_all_keys: true
 
     # Persistent storage for GitHub Copilot OAuth tokens
     volumes:

--- a/kubernetes/apps/base/litellm/network.yaml
+++ b/kubernetes/apps/base/litellm/network.yaml
@@ -145,3 +145,7 @@ spec:
         - ports:
             - port: smtp
               protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: toolhive
+            app: mcpserver

--- a/kubernetes/apps/base/toolhive/crds/helm.yaml
+++ b/kubernetes/apps/base/toolhive/crds/helm.yaml
@@ -1,0 +1,22 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator-crds
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.34.0
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-operator-crds
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-operator-crds

--- a/kubernetes/apps/base/toolhive/crds/kustomization.yaml
+++ b/kubernetes/apps/base/toolhive/crds/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: toolhive
+
+resources:
+  - helm.yaml

--- a/kubernetes/apps/base/toolhive/ks.yaml
+++ b/kubernetes/apps/base/toolhive/ks.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app toolhive-operator-crds
+  namespace: &namespace toolhive
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  path: ./kubernetes/apps/toolhive/crds
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app toolhive-operator
+  namespace: &namespace toolhive
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: toolhive-operator-crds
+      namespace: *namespace
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  path: ./kubernetes/apps/toolhive/operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h

--- a/kubernetes/apps/base/toolhive/ks.yaml
+++ b/kubernetes/apps/base/toolhive/ks.yaml
@@ -14,7 +14,7 @@ spec:
       kind: HelmRelease
       name: *app
       namespace: *namespace
-  path: ./kubernetes/apps/toolhive/crds
+  path: ./kubernetes/apps/base/toolhive/crds
   prune: true
   sourceRef:
     kind: GitRepository
@@ -40,7 +40,7 @@ spec:
       kind: HelmRelease
       name: *app
       namespace: *namespace
-  path: ./kubernetes/apps/toolhive/operator
+  path: ./kubernetes/apps/base/toolhive/operator
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/base/toolhive/ks.yaml
+++ b/kubernetes/apps/base/toolhive/ks.yaml
@@ -47,3 +47,24 @@ spec:
     name: flux-system
     namespace: flux-system
   interval: 1h
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mcp
+  namespace: &namespace toolhive
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: toolhive-operator
+      namespace: *namespace
+  path: ./kubernetes/apps/base/toolhive/mcp
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h

--- a/kubernetes/apps/base/toolhive/kustomization.yaml
+++ b/kubernetes/apps/base/toolhive/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: toolhive
 
 resources:
   - ks.yaml
+  - namespace.yaml

--- a/kubernetes/apps/base/toolhive/kustomization.yaml
+++ b/kubernetes/apps/base/toolhive/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: toolhive
+
+resources:
+  - ks.yaml

--- a/kubernetes/apps/base/toolhive/mcp/kustomization.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: toolhive
 
 resources:
   - searxng.yaml
+  - playwright.yaml

--- a/kubernetes/apps/base/toolhive/mcp/kustomization.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: toolhive
+
+resources:
+  - searxng.yaml

--- a/kubernetes/apps/base/toolhive/mcp/kustomization.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/kustomization.yaml
@@ -5,4 +5,5 @@ namespace: toolhive
 
 resources:
   - searxng.yaml
-  - playwright.yaml
+  - terraform.yaml
+  # - playwright.yaml

--- a/kubernetes/apps/base/toolhive/mcp/playwright.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/playwright.yaml
@@ -10,8 +10,12 @@ spec:
       volumes:
         - name: home
           emptyDir: {}
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: mcp
           volumeMounts:
             - name: home
               mountPath: /home/node
+            - name: tmp
+              mountPath: /tmp

--- a/kubernetes/apps/base/toolhive/mcp/playwright.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/playwright.yaml
@@ -1,0 +1,7 @@
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: playwright
+spec:
+  image: mcr.microsoft.com/playwright/mcp:v0.0.78@sha256:3d871c22ea2d4cca0966e2cfb1860e1cb03eb7353725a3d6cffd133296fb04eb
+  transport: stdio

--- a/kubernetes/apps/base/toolhive/mcp/playwright.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/playwright.yaml
@@ -5,3 +5,13 @@ metadata:
 spec:
   image: mcr.microsoft.com/playwright/mcp:v0.0.78@sha256:3d871c22ea2d4cca0966e2cfb1860e1cb03eb7353725a3d6cffd133296fb04eb
   transport: stdio
+  podTemplateSpec:
+    spec:
+      volumes:
+        - name: home
+          emptyDir: {}
+      containers:
+        - name: mcp
+          volumeMounts:
+            - name: home
+              mountPath: /home/node

--- a/kubernetes/apps/base/toolhive/mcp/playwright.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/playwright.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   image: mcr.microsoft.com/playwright/mcp:v0.0.78@sha256:3d871c22ea2d4cca0966e2cfb1860e1cb03eb7353725a3d6cffd133296fb04eb
   transport: stdio
+  env:
+    - name: PLAYWRIGHT_MCP_ISOLATED
+      value: "true"
   podTemplateSpec:
     spec:
       volumes:

--- a/kubernetes/apps/base/toolhive/mcp/searxng.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/searxng.yaml
@@ -1,0 +1,10 @@
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: searxng-mcp
+spec:
+  image: docker.io/isokoliuk/mcp-searxng:1.11.1@sha256:b6727fc950cf1a7501d70f863b563d9fc689d6e33c773296ed845070c5646b48
+  transport: stdio
+  env:
+    - name: SEARXNG_URL
+      value: http://searxng.searxng.svc.cluster.local:8080

--- a/kubernetes/apps/base/toolhive/mcp/searxng.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/searxng.yaml
@@ -7,4 +7,4 @@ spec:
   transport: stdio
   env:
     - name: SEARXNG_URL
-      value: http://searxng.searxng.svc.cluster.local:8080
+      value: http://searxng.searxng.svc.cluster.local

--- a/kubernetes/apps/base/toolhive/mcp/searxng.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/searxng.yaml
@@ -1,7 +1,7 @@
 apiVersion: toolhive.stacklok.dev/v1beta1
 kind: MCPServer
 metadata:
-  name: searxng-mcp
+  name: searxng
 spec:
   image: docker.io/isokoliuk/mcp-searxng:1.11.1@sha256:b6727fc950cf1a7501d70f863b563d9fc689d6e33c773296ed845070c5646b48
   transport: stdio

--- a/kubernetes/apps/base/toolhive/mcp/terraform.yaml
+++ b/kubernetes/apps/base/toolhive/mcp/terraform.yaml
@@ -1,0 +1,7 @@
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: terraform
+spec:
+  image: hashicorp/terraform-mcp-server:1.1.0@sha256:312d63756b5474df384b1844af55b58ca48cbe0996871e1d6c4239bfcd6fcd29
+  transport: stdio

--- a/kubernetes/apps/base/toolhive/namespace.yaml
+++ b/kubernetes/apps/base/toolhive/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: toolhive

--- a/kubernetes/apps/base/toolhive/operator/helm.yaml
+++ b/kubernetes/apps/base/toolhive/operator/helm.yaml
@@ -1,0 +1,31 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.34.0
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-operator
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-operator
+  values:
+    operator:
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 10m
+          memory: &memory 256Mi
+        limits:
+          memory: *memory

--- a/kubernetes/apps/base/toolhive/operator/kustomization.yaml
+++ b/kubernetes/apps/base/toolhive/operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: toolhive

--- a/kubernetes/apps/base/toolhive/operator/kustomization.yaml
+++ b/kubernetes/apps/base/toolhive/operator/kustomization.yaml
@@ -2,3 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 namespace: toolhive
+
+resources:
+  - helm.yaml

--- a/kubernetes/apps/overlays/dev/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/kustomization.yaml
@@ -10,10 +10,10 @@ resources:
   # - harbor
   # - immich
   # - joplin
-  # - litellm
+  - litellm
   # - n8n
   # - netbox
-  - openwebui
+  # - openwebui
   # - paperless
   - searxng
   # - tika

--- a/kubernetes/apps/overlays/dev/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/kustomization.yaml
@@ -13,9 +13,9 @@ resources:
   # - litellm
   # - n8n
   # - netbox
-  # - openwebui
+  - openwebui
   # - paperless
-  # - searxng
+  - searxng
   # - tika
   # - termix
   # - uptime

--- a/kubernetes/apps/overlays/dev/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/kustomization.yaml
@@ -10,14 +10,15 @@ resources:
   # - harbor
   # - immich
   # - joplin
-  - litellm
+  # - litellm
   # - n8n
   # - netbox
-  - openwebui
+  # - openwebui
   # - paperless
   # - searxng
-  - tika
+  # - tika
   # - termix
   # - uptime
   # - vault
   # - vaultwarden
+  - ../../base/toolhive

--- a/kubernetes/apps/overlays/dev/openwebui/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/openwebui/kustomization.yaml
@@ -19,23 +19,6 @@ patches:
     target:
       kind: Cluster
   - patch: |-
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/4
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/5
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/6
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/7
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/8
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/9
-      - op: remove
-        path: /spec/values/controllers/main/containers/main/env/10
-    target:
-      kind: HelmRelease
-  - patch: |-
       - op: replace
         path: /spec/jobTemplate/spec/template/spec/containers/0/env/3/value
         value: test
@@ -51,3 +34,16 @@ patches:
     target:
       kind: CiliumNetworkPolicy
       name: openwebui-sync
+  - patch: |-
+      # Disable OIDC and use built-in username/password auth in dev.
+      # env index 8 = ENABLE_OAUTH_SIGNUP, index 9 = ENABLE_LOGIN_FORM
+      # (see kubernetes/apps/base/openwebui/helm.yaml)
+      - op: replace
+        path: /spec/values/controllers/main/containers/main/env/8/value
+        value: "false"
+      - op: replace
+        path: /spec/values/controllers/main/containers/main/env/9/value
+        value: "true"
+    target:
+      kind: HelmRelease
+      name: openwebui

--- a/kubernetes/infrastructure/overlays/dev/platform/flux/instance/helm.yaml
+++ b/kubernetes/infrastructure/overlays/dev/platform/flux/instance/helm.yaml
@@ -7,4 +7,4 @@ spec:
     instance:
       sync:
         path: kubernetes/clusters/dev
-        ref: refs/heads/feat/rook-ceph-sync
+        ref: refs/heads/feat/add-toolhive-operator


### PR DESCRIPTION
## Summary

Adds the ToolHive operator and deploys MCP servers through it, plus supporting litellm, searxng, and openwebui changes.

## Changes

- **ToolHive operator** — add operator + CRDs to `kubernetes/apps/base/toolhive`, deploy in dev
- **MCP servers** — deploy Playwright, Searxng, and Terraform MCP servers via ToolHive
- **LiteLLM** — deploy in dev; allow egress to MCP server; add Terraform routing
- **Open WebUI** — disable OIDC in dev overlay (use built-in login); adjust dev kustomization paths
- **Platform** — fix kustomization paths; change dev cluster ref; allow all keys for MCPs; fix searxng port; add tmp/home folder to MCP server
- **Renovate** — group toolhive-operator and rook-ceph updates
- **Flake / Taskfile** — dev shell and task runner updates

## Commits

$(git log --oneline main..HEAD | sed 's/^/- /')

## Checklist

- [ ] Builds pass (`task kubernetes:build PATH=...`)
- [ ] Reconciled on dev cluster