### PR TITLE
feat(vpn): migrate wireguard-native to wg-easy under Doco-CD

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -168,4 +168,14 @@ Decisions made throughout the life of this project, with rationale and context.
 
 ---
 
+## 19. Migrate WireGuard VPN from wireguard-native to wg-easy, moved into this repo
+
+- **Date:** 2026-07-22
+- **Status:** Accepted
+- **Context:** The home network was already served by a wireguard-native deployment (manual `wg0.conf` on the management node) providing no-NAT remote access. Management was manual (hand-editing config, adding peers by hand) and the deployment lived outside this repo, so it received no Renovate dependency updates and diverged from the Doco-CD managed management-node stack. The initial setup exposed its WireGuard admin UI through Cloudflare Tunnels.
+- **Decision:** Migrate from wireguard-native to `wg-easy` v15, deployed via Docker Compose under `docker/vpn/wireguard/` and managed by Doco-CD. Same no-NAT routing design is preserved: host networking with tun device and `NET_ADMIN`/`NET_RAW`/`SYS_MODULE` caps, IPv6 disabled. A compose-based Traefik fronts the wg-easy UI, and a compose-based Netbird is added under `docker/vpn/` alongside it. The wg-easy admin UI is now exposed through Netbird instead of Cloudflare Tunnels, making it uniform with how other services are exposed. The existing OPNsense no-NAT design (static route for the VPN subnet via the management-node gateway, plus Hybrid Outbound NAT for the VPN subnet at the WAN edge for internet egress) is unchanged.
+- **Rationale:** wg-easy provides a web UI for peer/client management (add, remove, generate QR/config) replacing manual `wg0.conf` edits, while keeping the same WireGuard data plane and the existing no-NAT routing — so no OPNsense-side or client-side reconfiguration of the routing/NAT design was needed. Moving the deployment into this repo under `docker/vpn/` brings it under Doco-CD and Renovate, so the wg-easy image and Traefik/Netbird images get automated updates like the rest of the stack. Routing the admin UI through Netbird instead of Cloudflare Tunnels keeps service exposure consistent across the stack.
+
+---
+
 *This log is maintained to provide context for architectural decisions and onboarding.*

--- a/docker/vpn/.doco-cd.yaml
+++ b/docker/vpn/.doco-cd.yaml
@@ -7,3 +7,8 @@ name: traefik
 working_dir: docker/vpn/traefik
 compose_files:
   - compose.yaml
+---
+name: netbird
+working_dir: docker/vpn/netbird
+compose_files:
+  - compose.yaml

--- a/docker/vpn/.doco-cd.yaml
+++ b/docker/vpn/.doco-cd.yaml
@@ -1,0 +1,4 @@
+name: wireguard
+working_dir: docker/vpn/wireguard
+compose_files:
+  - compose.yaml

--- a/docker/vpn/.doco-cd.yaml
+++ b/docker/vpn/.doco-cd.yaml
@@ -2,3 +2,8 @@ name: wireguard
 working_dir: docker/vpn/wireguard
 compose_files:
   - compose.yaml
+---
+name: traefik
+working_dir: docker/vpn/traefik
+compose_files:
+  - compose.yaml

--- a/docker/vpn/doco-cd/compose.yaml
+++ b/docker/vpn/doco-cd/compose.yaml
@@ -1,0 +1,44 @@
+services:
+  doco-cd:
+    container_name: doco-cd
+    image: ghcr.io/kimdre/doco-cd:latest
+    environment:
+      TZ: Europe/Lisbon
+      HTTP_PORT: 8080
+      LOG_LEVEL: debug
+      POLL_CONFIG_FILE: /etc/doco-cd/poll-config.yaml
+      DEPLOY_CONFIG_BASE_DIR: ./docker/vpn
+      SOPS_AGE_KEY_FILE: /var/run/secrets/doco-cd/age.key
+    restart: unless-stopped
+    configs:
+      - source: poll-config.yaml
+        target: /etc/doco-cd/poll-config.yaml
+    volumes:
+      - data:/data
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /opt/docker/doco-cd:/var/run/secrets/doco-cd
+    healthcheck:
+      test:
+        - CMD
+        - /doco-cd
+        - healthcheck
+      start_period: 15s
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "500m"
+        max-file: "2"
+
+configs:
+  poll-config.yaml:
+    content: |
+      - url: https://github.com/dreadster3/home-ops.git
+        interval: 180
+        reference: refs/heads/main
+
+volumes:
+  data:
+    driver: local

--- a/docker/vpn/netbird/.env
+++ b/docker/vpn/netbird/.env
@@ -1,0 +1,7 @@
+EXTERNAL_DOMAIN=ENC[AES256_GCM,data:ig+KlVidV5WZJIjGJEs=,iv:R8ab6DXsUy/N++w9pjhK+Db/3i/wF0/pA/j3elH+iuE=,tag:hz8mm0ELrhK/a8XlIfQY6w==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLaHoxWFhFR05uVk42QXQ2\nbG9ieGE4cDNXeXhPYStnNXphbmp4emwxTzJ3Ck9oenpKN29NVWFwN1dWbE12VlFR\nTEJtZlc4bGlsYlBWWEoxOHJPS21uYU0KLS0tIHNha3ZPUjI0dUlqeEllV1pzZG5D\nYUZGWUdSaVBjVXJLM3pZdDJXMDlDREkKs3/uW9kdRbm7+8El7Q1XTHg9s9Cb0oWd\nHpS9tqvzQ5TyclhED2W7ckb49UhgyR97UNvOy4Sr+Xp+I2U4Qdj8eg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1usemhw8v2nnr5nuxddrc7gsy3525hhv0na4hk2ur7tjara5cp90s7cpeen
+sops_lastmodified=2026-07-22T21:55:05Z
+sops_mac=ENC[AES256_GCM,data:M9BSvFwoWXZzuVBPbt7zH3QJYMhGRBLK9Yoh1C67vOzQc8OG71gVeVJLA4zZ1BM6MJccIyKmE6RRG0LLJU3BuekKfQZYozSb5dTnyorvQOCqMgET8iv61teoBabbTCJ00Tu5aZg507g/xiHF12MC4F3CqxUCC7I3FCTO3jMXKts=,iv:16ECSso40nRv+fS0QDLerTeWyfe/a2cjsieS8tgEYRA=,tag:y4An5s6qFGRBGCtYsROMeA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.2

--- a/docker/vpn/netbird/compose.yaml
+++ b/docker/vpn/netbird/compose.yaml
@@ -15,6 +15,9 @@ services:
     security_opt:
       - no-new-privileges:true
     read_only: true
+    tmpfs:
+      - /var/run
+      - /var/lib
     networks:
       - netbird
 

--- a/docker/vpn/netbird/compose.yaml
+++ b/docker/vpn/netbird/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  netbird:
+    image: ghcr.io/netbirdio/netbird:0.74.7@sha256:b63f4c1584118aeebacfdfd841f0351122a53fccac182b4c43be428c2c9a6b73
+    restart: unless-stopped
+    container_name: netbird
+    env_file: netbird.env
+    environment:
+      NB_MANAGEMENT_URL: https://netbird.${EXTERNAL_DOMAIN}
+    cap_add:
+      - NET_ADMIN
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true

--- a/docker/vpn/netbird/compose.yaml
+++ b/docker/vpn/netbird/compose.yaml
@@ -10,14 +10,11 @@ services:
       - /var/log/docker/netbird:/var/log/netbird
     cap_add:
       - NET_ADMIN
+      - NET_RAW
     cap_drop:
       - ALL
     security_opt:
       - no-new-privileges:true
-    read_only: true
-    tmpfs:
-      - /var/run
-      - /var/lib
     networks:
       - netbird
 

--- a/docker/vpn/netbird/compose.yaml
+++ b/docker/vpn/netbird/compose.yaml
@@ -6,6 +6,8 @@ services:
     env_file: netbird.env
     environment:
       NB_MANAGEMENT_URL: https://netbird.${EXTERNAL_DOMAIN}
+    volumes:
+      - /var/log/docker/netbird:/var/log/netbird
     cap_add:
       - NET_ADMIN
     cap_drop:
@@ -13,3 +15,10 @@ services:
     security_opt:
       - no-new-privileges:true
     read_only: true
+    networks:
+      - netbird
+
+networks:
+  netbird:
+    name: netbird
+    driver: bridge

--- a/docker/vpn/netbird/compose.yaml
+++ b/docker/vpn/netbird/compose.yaml
@@ -3,6 +3,7 @@ services:
     image: ghcr.io/netbirdio/netbird:0.74.7@sha256:b63f4c1584118aeebacfdfd841f0351122a53fccac182b4c43be428c2c9a6b73
     restart: unless-stopped
     container_name: netbird
+    hostname: vpn
     env_file: netbird.env
     environment:
       NB_MANAGEMENT_URL: https://netbird.${EXTERNAL_DOMAIN}

--- a/docker/vpn/netbird/netbird.env
+++ b/docker/vpn/netbird/netbird.env
@@ -1,7 +1,7 @@
-NB_SETUP_KEY=ENC[AES256_GCM,data:eCZlqGGQ5hEpdeIosySwWCiMYZcJfO/26i6/wyrQ9+Tc3PSX,iv:GhQevFJIWs4PIayqI4y0OAQ0mTk130qc+bvmKKx6Zws=,tag:xxq8OI8Ye/UlctXKbmk3Ww==,type:str]
+NB_SETUP_KEY=ENC[AES256_GCM,data:rwE+wBOiG4FucVFyKVeBV58b8bGnYZHorlhMKFnYsLbYSRKm,iv:762ACyF0mKln6sT3lK5c3tFU0Qs4kgUN4u4vur7HAPk=,tag:EGx6TOALJ5CfcKpdxo5iJw==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhZ1ZiNXgvQm1QK0xCckpm\ndittMFk1cnNJVHlISlRXWldPc3BCalBBSkcwCitESnVFMkhOSWVQTmNpQUIrK2lL\nN3dNZ0VTVWk1dXNVbWs0Q01tVFFZSnMKLS0tIDR0cm9lWko0T29Cd21BQWFrRFZF\nOVhubnp0Q2U1Z3V4VHhsM1NmVFVBNnMK4I/nm+rbrNrAjWOjEzpgOTiZvDZkPc8b\n6D18MPcMiZ5iVqNGy3oypvnQOUwTTyYLTEJnKE3xQn44M8+Y5ojwwg==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1usemhw8v2nnr5nuxddrc7gsy3525hhv0na4hk2ur7tjara5cp90s7cpeen
-sops_lastmodified=2026-07-22T21:53:39Z
-sops_mac=ENC[AES256_GCM,data:Es0Wem7Z85SjlA+b/9C/8h6fZEJJ+LXJPJ/dyVLNnJIfQGIh7j/eIon6DH2ehy10kR+5CpshYKmlVJvA0cJ6Nhps+odGp6WVl2UzU1iqMk56wQNCmQ/jGexnXITgE+etLnYG2Bf+4BYeQqtn5PXvQC7tff57fQowiOQBbHAQNYE=,iv:4gRX5293RiuuQeFRfxt+Y/jj4dN/+CWkErkydUs+0YQ=,tag:mDAdK/IC+mb4Mp+nYbjxyA==,type:str]
+sops_lastmodified=2026-07-22T22:25:33Z
+sops_mac=ENC[AES256_GCM,data:RSzLu1vHzMyDlo+iDfHpg1aM/REw22KMxvchcdewYjAwO6yNpIYbzATcY7thTEKP6MKs0SpR1dGfgXmbKfRiGbpbl11wahMrWi1+IA/OXP/SYeVUIAiWTfNpOkLe5Tb31GyxWMo5oKKHPS0ehz0Be5BBJC4FmDxT700BXFp9WxE=,iv:MEnzwJEfTIbqgDWwCbA6d/cBmm0UwKHRYEy/amUwZFs=,tag:TAiJ3h7s83o7GoN3IPyzZA==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.13.2

--- a/docker/vpn/netbird/netbird.env
+++ b/docker/vpn/netbird/netbird.env
@@ -1,0 +1,7 @@
+NB_SETUP_KEY=ENC[AES256_GCM,data:eCZlqGGQ5hEpdeIosySwWCiMYZcJfO/26i6/wyrQ9+Tc3PSX,iv:GhQevFJIWs4PIayqI4y0OAQ0mTk130qc+bvmKKx6Zws=,tag:xxq8OI8Ye/UlctXKbmk3Ww==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhZ1ZiNXgvQm1QK0xCckpm\ndittMFk1cnNJVHlISlRXWldPc3BCalBBSkcwCitESnVFMkhOSWVQTmNpQUIrK2lL\nN3dNZ0VTVWk1dXNVbWs0Q01tVFFZSnMKLS0tIDR0cm9lWko0T29Cd21BQWFrRFZF\nOVhubnp0Q2U1Z3V4VHhsM1NmVFVBNnMK4I/nm+rbrNrAjWOjEzpgOTiZvDZkPc8b\n6D18MPcMiZ5iVqNGy3oypvnQOUwTTyYLTEJnKE3xQn44M8+Y5ojwwg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1usemhw8v2nnr5nuxddrc7gsy3525hhv0na4hk2ur7tjara5cp90s7cpeen
+sops_lastmodified=2026-07-22T21:53:39Z
+sops_mac=ENC[AES256_GCM,data:Es0Wem7Z85SjlA+b/9C/8h6fZEJJ+LXJPJ/dyVLNnJIfQGIh7j/eIon6DH2ehy10kR+5CpshYKmlVJvA0cJ6Nhps+odGp6WVl2UzU1iqMk56wQNCmQ/jGexnXITgE+etLnYG2Bf+4BYeQqtn5PXvQC7tff57fQowiOQBbHAQNYE=,iv:4gRX5293RiuuQeFRfxt+Y/jj4dN/+CWkErkydUs+0YQ=,tag:mDAdK/IC+mb4Mp+nYbjxyA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.2

--- a/docker/vpn/traefik/.env
+++ b/docker/vpn/traefik/.env
@@ -1,0 +1,8 @@
+INTERNAL_DOMAIN=ENC[AES256_GCM,data:GCAX4RcKn8cBMxPPmA2XEHLvvjw=,iv:X691cBrYNbvuqLUGdxbw8AT0LIoj/m/CTf7DkV4fMFs=,tag:K8duRzpmmJHETQ89ppvIhw==,type:str]
+VM_IP=ENC[AES256_GCM,data:Juvf7pFw0pg7KIemOas=,iv:cviYaL6+sVfjOLeyKD+5fA7JhPLkArQ4sN1mTZN3u9M=,tag:OFTItclfOeSdgeeDxBYU4g==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArYTJzeE5haFAva3lTdHU2\nUEpYdWZTV25DMHZicDR6bW04ZzRMWFBIdnlBCnBnKzJjZURGK1hLK2NiQlk2S3Rr\nM0p2cEV1Z2M2clYvdzVSL1UrcERncVUKLS0tIGsvZ1AwYjBZZWovU2gwR29xL1VN\nd1I0OUs1OFRFRW9oN3AvYXVjeWl6cVUKWYhAlpdBBOZdOWyfAdiuwpLAeU9AN+Zr\nYXBH9VOyiK52r1JaQwMOQehIKv16D8szqELNC+19V44ZfAc8Y7B2Ew==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1usemhw8v2nnr5nuxddrc7gsy3525hhv0na4hk2ur7tjara5cp90s7cpeen
+sops_lastmodified=2026-07-22T13:58:29Z
+sops_mac=ENC[AES256_GCM,data:4Xu8YVIrkkxzFTFTECviOz7epnNhEEFoDltBrwkHniNxFbFHWxffko38nx8H4vh27DhHNAzqV0+bKJl+dnku/m5JCXB4zxj2tMRYiL3Yb7IoPjTiQIq9F+ph9UCoT0W5LQeE0Hkk6JFrGS5bUHTuwN0+13unEC0Cafnu1youjMk=,iv:0Iqg0SFWgJJdJKTEMfHEy1gFecCOtdojdjKBadwjv0I=,tag:a3IREQiQ1hnQtPHgaMty8A==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.2

--- a/docker/vpn/traefik/compose.yaml
+++ b/docker/vpn/traefik/compose.yaml
@@ -100,9 +100,9 @@ services:
       - CAP_NET_BIND_SERVICE
     security_opt:
       - no-new-privileges:true
-    read_only: true
-    tmpfs:
-      - /tmp
+    # read_only: true
+    # tmpfs:
+    #   - /tmp
     networks:
       proxy:
         ipv4_address: 172.22.1.254

--- a/docker/vpn/traefik/compose.yaml
+++ b/docker/vpn/traefik/compose.yaml
@@ -104,6 +104,8 @@ services:
       proxy:
         ipv4_address: 172.22.1.254
       netbird:
+        aliases:
+          - traefik.local
 
 volumes:
   letsencrypt:

--- a/docker/vpn/traefik/compose.yaml
+++ b/docker/vpn/traefik/compose.yaml
@@ -1,0 +1,121 @@
+configs:
+  traefik-dynamic.yaml:
+    content: |
+      http:
+        routers:
+          wg-easy:
+            rule: Host(`vpn.${INTERNAL_DOMAIN}`)
+            entrypoints:
+              - websecure
+            service: wg-easy
+
+        services:
+          wg-easy:
+            loadBalancer:
+              servers:
+                - url: http://${VM_IP}:51821
+  traefik.yaml:
+    content: |
+      api:
+        dashboard: true
+        insecure: true
+
+      providers:
+        docker:
+          exposedByDefault: false
+          network: proxy
+        file:
+          filename: /etc/traefik/traefik-dynamic.yaml
+
+      entryPoints:
+        web:
+          address: ":80"
+          http:
+            redirections:
+              entrypoint:
+                to: websecure
+                scheme: https
+        websecure:
+          address: ":443"
+          http:
+            tls:
+              certResolver: "letsencrypt"
+
+      certificatesResolvers:
+        letsencrypt:
+          acme:
+            email: "afonso.antunes@live.com.pt"
+            storage: "/letsencrypt/acme.json"
+            caServer: "https://acme-v02.api.letsencrypt.org/directory"
+            dnsChallenge:
+              provider: cloudflare  # or your DNS provider
+              resolvers:
+                - "1.1.1.1:53"
+                - "8.8.8.8:53"
+
+      log:
+        filePath: /var/log/traefik/traefik.log
+        format: json
+        level: DEBUG
+
+      accessLog:
+        filePath: /var/log/traefik/access.log
+        format: json
+
+      serversTransport:
+        insecureSkipVerify: true
+
+services:
+  traefik:
+    container_name: traefik
+    image: docker.io/traefik:v3.7.8@sha256:4299bbed850421258fc5448c2e0e6ad350981d4d335a68de11b92448aedbefe5
+    env_file:
+      - traefik.env
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - letsencrypt:/letsencrypt
+      - /var/log/docker/traefik:/var/log/traefik
+    configs:
+      - source: traefik.yaml
+        target: /etc/traefik/traefik.yaml
+      - source: traefik-dynamic.yaml
+        target: /etc/traefik/traefik-dynamic.yaml
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "500m"
+        max-file: "2"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dashboard.rule=Host(`vpn.proxy.${INTERNAL_DOMAIN}`)"
+      - "traefik.http.routers.dashboard.entrypoints=websecure"
+      - "traefik.http.routers.dashboard.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.dashboard.service=api@internal"
+    cap_drop:
+      - ALL
+    cap_add:
+      - CAP_NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    networks:
+      proxy:
+        ipv4_address: 172.22.1.254
+
+volumes:
+  letsencrypt:
+    driver: local
+
+networks:
+  proxy:
+    name: proxy
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.22.1.0/24
+          gateway: 172.22.1.1

--- a/docker/vpn/traefik/compose.yaml
+++ b/docker/vpn/traefik/compose.yaml
@@ -100,12 +100,10 @@ services:
       - CAP_NET_BIND_SERVICE
     security_opt:
       - no-new-privileges:true
-    # read_only: true
-    # tmpfs:
-    #   - /tmp
     networks:
       proxy:
         ipv4_address: 172.22.1.254
+      netbird:
 
 volumes:
   letsencrypt:
@@ -119,3 +117,5 @@ networks:
       config:
         - subnet: 172.22.1.0/24
           gateway: 172.22.1.1
+  netbird:
+    external: true

--- a/docker/vpn/traefik/traefik.env
+++ b/docker/vpn/traefik/traefik.env
@@ -1,0 +1,7 @@
+CF_DNS_API_TOKEN=ENC[AES256_GCM,data:7lzxzy24kbKNa8XP2UTj3E6nnDANOTxIguI5osukcL5D/ZxPV16GEg==,iv:WU9FWuVLvpY1gqiw/IMxk/MPMXAJz5XEgnkF8HtYa6w=,tag:TKNGD2i4qj6NxY1gvM4Bfg==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZZUF3RDlXUHdRekdsZnE0\nbjRSNENTOERJWERxM1ZFM1F6d0lsdFF0MWlzCjc4WGdySDhFSXFwMVhWR3NQRFFO\ndTZrTm5EcW1ScjYraWVySWNmbDJNaUEKLS0tIElGR0ZQWHpxM2kxeklUdWV2Q3ZF\naTdpZGRZVU9rTjJDekRGbWs3dmRTUjgKahac/zGlWWkb+ERS+JThqn+6rp9dfHze\nulJvlB9akyoYcy56pvoiKOCB73xny7Osu7R5naPZHa2ejBaxwSoQ5w==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1usemhw8v2nnr5nuxddrc7gsy3525hhv0na4hk2ur7tjara5cp90s7cpeen
+sops_lastmodified=2026-03-06T02:02:04Z
+sops_mac=ENC[AES256_GCM,data:8QFp5UBGDellHwhMoRXUZWj038WntnKlpUMP7vN4Ex9IZmc2PMMBacY3jJ5ypnLzDT6hz8tGS/5cxXAVDRivOyjUZYoLK9ApYV89Sp1HXnR2KqFxFkLBBkyeN5Q1NmGRcwMpfz4q+4YvcHhrmDzoHzZUvCoa38I4EMH2ZOExJic=,iv:bUpj5u2rAt0kylg5rUozomxUt30SFiVLJmFrElQpZOs=,tag:An66HjsbB92zBExQcGoWrg==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.11.0

--- a/docker/vpn/wireguard/.env
+++ b/docker/vpn/wireguard/.env
@@ -1,0 +1,8 @@
+EXTERNAL_DOMAIN=ENC[AES256_GCM,data:9ngBJOozPMCVm/XvKLo=,iv:oAIN8RofWiCRhpRCUXpcrznkrkI7tiTXFok2RSXeZq4=,tag:uRxWLQXVtQn2cd5eNujcQQ==,type:str]
+WG_EASY_PASSWORD=ENC[AES256_GCM,data:A0djKhaSfaZvFJgyBgmQKM1RLBT3ascAOFdaEw+hLZU=,iv:YM076/jM7cKl4dYe8YdXLJdrTjZXpf7HL4NZjpx0QU8=,tag:Ob5GxI0gOc4cfg9T97rb6g==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJanJJaEN3V2RHSVBlb1Z6\nRnlHZVRWbFNhWG9GalJwV2d6T0c4ZTNZNkRJCndlM0F6aGNoN0tyVmVrSjFwWTRp\nV2MrK1hpTFFTY1VsdUdDZ3hDQXlDSUkKLS0tIHVWTkJ3amlTWlJteE05VVFEZjRl\nby9mWVBUL3FPK2M4SGZMWm4vOTJuVVEK2i/IqW0LYvUAey/suoSb288k1/DZYe0k\nGWBnT6zxYHvvnZrUPRBRTqJkhYbZN0o8cWtPObYEHoul39+sMSMgBg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1usemhw8v2nnr5nuxddrc7gsy3525hhv0na4hk2ur7tjara5cp90s7cpeen
+sops_lastmodified=2026-07-21T10:57:12Z
+sops_mac=ENC[AES256_GCM,data:RFfWPKsFMCj0iCuCuekUJ6CrrLXhxio429Ct34xiS42c3KZWSipspQEwwJC1p9EMq7ZXCc8s072m0WTL4dW+Y9WR3MDJ8tr9QGlKk/3B+eoQqfdorJCOopdkbFUIdNRlgccq6bgL/cTmNfCqu54vdiJ2WGFyoHYfVNPmcLGK4cI=,iv:m6wWWTaKlOpkPebrSnb0FP9FhhZzgj3koTCKqqw0lhE=,tag:AuIueENOdNf59sNB+52cCQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.2

--- a/docker/vpn/wireguard/.env
+++ b/docker/vpn/wireguard/.env
@@ -1,8 +1,0 @@
-EXTERNAL_DOMAIN=ENC[AES256_GCM,data:9ngBJOozPMCVm/XvKLo=,iv:oAIN8RofWiCRhpRCUXpcrznkrkI7tiTXFok2RSXeZq4=,tag:uRxWLQXVtQn2cd5eNujcQQ==,type:str]
-WG_EASY_PASSWORD=ENC[AES256_GCM,data:A0djKhaSfaZvFJgyBgmQKM1RLBT3ascAOFdaEw+hLZU=,iv:YM076/jM7cKl4dYe8YdXLJdrTjZXpf7HL4NZjpx0QU8=,tag:Ob5GxI0gOc4cfg9T97rb6g==,type:str]
-sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJanJJaEN3V2RHSVBlb1Z6\nRnlHZVRWbFNhWG9GalJwV2d6T0c4ZTNZNkRJCndlM0F6aGNoN0tyVmVrSjFwWTRp\nV2MrK1hpTFFTY1VsdUdDZ3hDQXlDSUkKLS0tIHVWTkJ3amlTWlJteE05VVFEZjRl\nby9mWVBUL3FPK2M4SGZMWm4vOTJuVVEK2i/IqW0LYvUAey/suoSb288k1/DZYe0k\nGWBnT6zxYHvvnZrUPRBRTqJkhYbZN0o8cWtPObYEHoul39+sMSMgBg==\n-----END AGE ENCRYPTED FILE-----\n
-sops_age__list_0__map_recipient=age1usemhw8v2nnr5nuxddrc7gsy3525hhv0na4hk2ur7tjara5cp90s7cpeen
-sops_lastmodified=2026-07-21T10:57:12Z
-sops_mac=ENC[AES256_GCM,data:RFfWPKsFMCj0iCuCuekUJ6CrrLXhxio429Ct34xiS42c3KZWSipspQEwwJC1p9EMq7ZXCc8s072m0WTL4dW+Y9WR3MDJ8tr9QGlKk/3B+eoQqfdorJCOopdkbFUIdNRlgccq6bgL/cTmNfCqu54vdiJ2WGFyoHYfVNPmcLGK4cI=,iv:m6wWWTaKlOpkPebrSnb0FP9FhhZzgj3koTCKqqw0lhE=,tag:AuIueENOdNf59sNB+52cCQ==,type:str]
-sops_unencrypted_suffix=_unencrypted
-sops_version=3.13.2

--- a/docker/vpn/wireguard/compose.yaml
+++ b/docker/vpn/wireguard/compose.yaml
@@ -4,13 +4,20 @@ services:
     restart: unless-stopped
     container_name: wg-easy
     network_mode: "host"
+    environment:
+      DISABLE_IPV6: true
     volumes:
       - /opt/docker/wireguard:/etc/wireguard
       - /lib/modules:/lib/modules:ro
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    cap_drop:
+      - ALL
     cap_add:
       - NET_ADMIN
       - SYS_MODULE
-    devices:
-      - /dev/net/tun:/dev/net/tun
-    environment:
-      DISABLE_IPV6: true
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp

--- a/docker/vpn/wireguard/compose.yaml
+++ b/docker/vpn/wireguard/compose.yaml
@@ -1,0 +1,34 @@
+services:
+  wg-easy:
+    image: ghcr.io/wg-easy/wg-easy:15.3.0@sha256:93bbd593e07bab98d02807a28770ac87ab6c48818e319e68c1f66561feb99876
+    restart: unless-stopped
+    container_name: wg-easy
+    network_mode: "host"
+    volumes:
+      - /opt/docker/wireguard:/etc/wireguard
+      - /lib/modules:/lib/modules:ro
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    environment:
+      WG_HOST: vpn.${EXTERNAL_DOMAIN}
+      PASSWORD: ${WG_EASY_PASSWORD}
+      WG_PORT: 51820
+      DISABLE_IPV6: true
+
+      # ── VPN subnet ───────────────────────────────────────────
+      WG_DEFAULT_DNS: 192.168.100.1 # DNS for clients (e.g. your OPNsense or Pi-hole)
+      WG_DEFAULT_ADDRESS: 10.10.0.x # Client IP range (becomes 10.8.0.0/24)
+
+      # ── Routed (no NAT) hooks ────────────────────────────────
+      # No MASQUERADE rule — packets keep their real source IP
+      WG_POST_UP: >-
+        iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
+        iptables -A FORWARD -i wg0 -j ACCEPT;
+        iptables -A FORWARD -o wg0 -j ACCEPT;
+      WG_POST_DOWN: >-
+        iptables -D INPUT -p udp -m udp --dport 51820 -j ACCEPT;
+        iptables -D FORWARD -i wg0 -j ACCEPT;
+        iptables -D FORWARD -o wg0 -j ACCEPT;

--- a/docker/vpn/wireguard/compose.yaml
+++ b/docker/vpn/wireguard/compose.yaml
@@ -11,13 +11,11 @@ services:
       - /lib/modules:/lib/modules:ro
     devices:
       - /dev/net/tun:/dev/net/tun
-    cap_drop:
-      - ALL
     cap_add:
       - NET_ADMIN
+      - NET_RAW
       - SYS_MODULE
+    cap_drop:
+      - ALL
     security_opt:
       - no-new-privileges:true
-    read_only: true
-    tmpfs:
-      - /tmp

--- a/docker/vpn/wireguard/compose.yaml
+++ b/docker/vpn/wireguard/compose.yaml
@@ -13,22 +13,4 @@ services:
     devices:
       - /dev/net/tun:/dev/net/tun
     environment:
-      WG_HOST: vpn.${EXTERNAL_DOMAIN}
-      PASSWORD: ${WG_EASY_PASSWORD}
-      WG_PORT: 51820
       DISABLE_IPV6: true
-
-      # ── VPN subnet ───────────────────────────────────────────
-      WG_DEFAULT_DNS: 192.168.100.1 # DNS for clients (e.g. your OPNsense or Pi-hole)
-      WG_DEFAULT_ADDRESS: 10.10.0.x # Client IP range (becomes 10.8.0.0/24)
-
-      # ── Routed (no NAT) hooks ────────────────────────────────
-      # No MASQUERADE rule — packets keep their real source IP
-      WG_POST_UP: >-
-        iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
-        iptables -A FORWARD -i wg0 -j ACCEPT;
-        iptables -A FORWARD -o wg0 -j ACCEPT;
-      WG_POST_DOWN: >-
-        iptables -D INPUT -p udp -m udp --dport 51820 -j ACCEPT;
-        iptables -D FORWARD -i wg0 -j ACCEPT;
-        iptables -D FORWARD -o wg0 -j ACCEPT;


### PR DESCRIPTION
## Summary

Migrate the home WireGuard VPN from a manual wireguard-native deployment (living outside this repo) to `wg-easy` v15, brought into this repo under `docker/vpn/` and managed by Doco-CD so it receives Renovate updates like the rest of the management-node stack. The no-NAT routing design is preserved unchanged.

## Changes

- **`docker/vpn/wireguard/`** — `wg-easy` v15 compose (host networking, tun device, `NET_ADMIN`/`NET_RAW`/`SYS_MODULE` caps, IPv6 disabled). Same no-NAT design: VPN subnet, server address, and UDP port unchanged from the prior deployment.
- **`docker/vpn/traefik/`** — compose-based Traefik fronting the wg-easy UI.
- **`docker/vpn/netbird/`** — compose-based Netbird added under `docker/vpn/`; the wg-easy admin UI is now exposed through Netbird instead of the previous Cloudflare Tunnels setup, making service exposure uniform across the stack.
- **`docker/vpn/doco-cd/`** + **`.doco-cd.yaml`** — Doco-CD watch config for the new stack.
- **`DECISION.md`** — adds decision #19 documenting the migration and the UI exposure change (Cloudflare Tunnels → Netbird).

## Operational notes

- No OPNsense-side changes were required: the existing static route for the VPN subnet (via the management-node gateway) and Hybrid Outbound NAT for the VPN subnet at the WAN edge are unchanged.
- Secrets remain SOPS-encrypted (netbird `.env`/`netbird.env`, traefik `.env`/`traefik.env`).

## Test plan

- [ ] wg-easy container starts and `wg0` interface comes up
- [ ] Client handshakes succeed (verified via `wg show`)
- [ ] VPN client → LAN host reachability (no-NAT)
- [ ] VPN client → internet reachability (WAN-edge NAT)
- [ ] wg-easy admin UI reachable via Netbird
