### PR TITLE
feat(qdrant): deploy qdrant database

### DIFF
--- a/kubernetes/apps/base/litellm/network.yaml
+++ b/kubernetes/apps/base/litellm/network.yaml
@@ -161,3 +161,13 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: toolhive
             app: mcpremoteproxy
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: qdrant
+            app.kubernetes.io/name: qdrant
+      toPorts:
+        - ports:
+            - port: "6333"
+              protocol: TCP
+            - port: "6334"
+              protocol: TCP

--- a/kubernetes/apps/base/openwebui/network.yaml
+++ b/kubernetes/apps/base/openwebui/network.yaml
@@ -134,6 +134,16 @@ spec:
               protocol: TCP
     - toEndpoints:
         - matchLabels:
+            io.kubernetes.pod.namespace: qdrant
+            app.kubernetes.io/name: qdrant
+      toPorts:
+        - ports:
+            - port: "6333"
+              protocol: TCP
+            - port: "6334"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
             io.kubernetes.pod.namespace: tika
             app.kubernetes.io/name: tika
       toPorts:

--- a/kubernetes/infrastructure/base/databases/kustomization.yaml
+++ b/kubernetes/infrastructure/base/databases/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - dragonfly
   # - redis-operator
   - cnpg
+  - qdrant

--- a/kubernetes/infrastructure/base/databases/qdrant/app/helm.yaml
+++ b/kubernetes/infrastructure/base/databases/qdrant/app/helm.yaml
@@ -1,0 +1,59 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: qdrant
+  namespace: qdrant
+spec:
+  interval: 24h
+  url: https://qdrant.github.io/qdrant-helm
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: qdrant
+  namespace: qdrant
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: qdrant
+      version: 1.x.x
+      interval: 24h
+      sourceRef:
+        kind: HelmRepository
+        name: qdrant
+  dependsOn:
+    - name: prometheus-operator
+      namespace: monitoring
+  values:
+    replicaCount: 3
+
+    resources:
+      requests:
+        cpu: 1000m
+        memory: &memory 1.5Gi
+      limits:
+        memory: *memory
+
+    persistence:
+      size: &disk 30Gi
+
+    snapshotPersistence:
+      enabled: true
+      size: *disk
+      storageClassName: nfs
+
+    config:
+      cluster:
+        enabled: true
+        p2p:
+          port: 6335
+          enable_tls: false
+        consensus:
+          tick_period_ms: 100
+      service:
+        enable_tls: false
+
+    metrics:
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/infrastructure/base/databases/qdrant/app/kustomization.yaml
+++ b/kubernetes/infrastructure/base/databases/qdrant/app/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: qdrant
 
 resources:
   - helm.yaml
+  - network.yaml

--- a/kubernetes/infrastructure/base/databases/qdrant/app/kustomization.yaml
+++ b/kubernetes/infrastructure/base/databases/qdrant/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: qdrant
+
+resources:
+  - helm.yaml

--- a/kubernetes/infrastructure/base/databases/qdrant/app/network.yaml
+++ b/kubernetes/infrastructure/base/databases/qdrant/app/network.yaml
@@ -9,8 +9,10 @@ spec:
   egress:
     - toEndpoints:
         - matchLabels:
-            "k8s:io.kubernetes.pod.namespace": qdrant
-  ingress: []
+            io.kubernetes.pod.namespace: qdrant
+  ingress:
+    - fromEndpoints:
+        matchLabels: {}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
@@ -25,20 +27,6 @@ spec:
       app.kubernetes.io/instance: qdrant
   ingress:
     - fromEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: qdrant
-            app.kubernetes.io/name: qdrant
-            app.kubernetes.io/instance: qdrant
-      toPorts:
-        - ports:
-            - port: "6333"
-              protocol: TCP
-            - port: "6334"
-              protocol: TCP
-            - port: "6335"
-              protocol: TCP
-  egress:
-    - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: qdrant
             app.kubernetes.io/name: qdrant

--- a/kubernetes/infrastructure/base/databases/qdrant/app/network.yaml
+++ b/kubernetes/infrastructure/base/databases/qdrant/app/network.yaml
@@ -1,0 +1,86 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-all-except-namespace
+  namespace: qdrant
+spec:
+  description: "Allow traffic only to the namespace itself"
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": qdrant
+  ingress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: qdrant-cluster
+  namespace: qdrant
+spec:
+  description: "Allow intra-cluster traffic between qdrant pods"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qdrant
+      app.kubernetes.io/instance: qdrant
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: qdrant
+            app.kubernetes.io/name: qdrant
+            app.kubernetes.io/instance: qdrant
+      toPorts:
+        - ports:
+            - port: "6333"
+              protocol: TCP
+            - port: "6334"
+              protocol: TCP
+            - port: "6335"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: qdrant
+            app.kubernetes.io/name: qdrant
+            app.kubernetes.io/instance: qdrant
+      toPorts:
+        - ports:
+            - port: "6333"
+              protocol: TCP
+            - port: "6334"
+              protocol: TCP
+            - port: "6335"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: qdrant-server
+  namespace: qdrant
+spec:
+  description: "Allow traffic from openwebui and litellm to qdrant"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: qdrant
+      app.kubernetes.io/instance: qdrant
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: openwebui
+            app.kubernetes.io/name: openwebui
+      toPorts:
+        - ports:
+            - port: "6333"
+              protocol: TCP
+            - port: "6334"
+              protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: litellm
+            app.kubernetes.io/name: litellm
+      toPorts:
+        - ports:
+            - port: "6333"
+              protocol: TCP
+            - port: "6334"
+              protocol: TCP

--- a/kubernetes/infrastructure/base/databases/qdrant/ks.yaml
+++ b/kubernetes/infrastructure/base/databases/qdrant/ks.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app qdrant
+  namespace: &namespace qdrant
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/module: *namespace
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  path: ./kubernetes/infrastructure/base/databases/qdrant/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  dependsOn:
+    - name: prometheus-operator
+      namespace: monitoring
+  interval: 1h
+  timeout: 5m

--- a/kubernetes/infrastructure/base/databases/qdrant/kustomization.yaml
+++ b/kubernetes/infrastructure/base/databases/qdrant/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: qdrant
+
+components:
+  - ../../../../components/substitute
+
+resources:
+  - namespace.yaml
+  - ks.yaml

--- a/kubernetes/infrastructure/base/databases/qdrant/namespace.yaml
+++ b/kubernetes/infrastructure/base/databases/qdrant/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: qdrant

--- a/kubernetes/infrastructure/overlays/dev/databases/qdrant/app/kustomization.yaml
+++ b/kubernetes/infrastructure/overlays/dev/databases/qdrant/app/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../../base/databases/qdrant/app
+
+patches:
+  - target:
+      kind: HelmRelease
+      name: qdrant
+    patch: |-
+      - op: remove
+        path: /spec/values/snapshotPersistence/storageClassName

--- a/kubernetes/infrastructure/overlays/dev/kustomization.yaml
+++ b/kubernetes/infrastructure/overlays/dev/kustomization.yaml
@@ -180,6 +180,13 @@ patches:
     kind: Kustomization
     name: alloy
 - patch: |-
+    - op: replace
+      path: /spec/path
+      value: ./kubernetes/infrastructure/overlays/dev/databases/qdrant/app
+  target:
+    kind: Kustomization
+    name: qdrant
+- patch: |-
     apiVersion: kustomize.toolkit.fluxcd.io/v1
     kind: Kustomization
     metadata:


### PR DESCRIPTION
## What

Deploy Qdrant as shared infrastructure for multiple apps in the cluster.

## Changes

- Add `qdrant` namespace + Flux Kustomization under `kubernetes/infrastructure/base/databases/qdrant/`
- HelmRelease from official `qdrant/qdrant-helm` repo
- **3 replicas** (clustered, `podManagementPolicy: Parallel`)
- **Resources**: 1 vCPU / 1.5Gi (requests + limits)
- **Persistence**: 30Gi (default `ceph-block`), snapshots 30Gi on `nfs` storage class (sizes tied via YAML anchor)
- **serviceMonitor**: enabled
- Dev overlay drops `storageClassName` so snapshots use the dev default storage class (NFS is prod-only)

## Notes

- Full dev overlay build fails on a pre-existing unrelated error (`observability/namespace.yaml` not a directory) — not caused by this change.