### PR TITLE
chore(kubernetes): remove netbird expose annotations

### DIFF
--- a/kubernetes/apps/base/authentik/helm.yaml
+++ b/kubernetes/apps/base/authentik/helm.yaml
@@ -75,8 +75,6 @@ spec:
           enabled: true
 
       service:
-        annotations:
-          netbird.io/expose: "true"
 
       route:
         main:

--- a/kubernetes/apps/base/authentik/helm.yaml
+++ b/kubernetes/apps/base/authentik/helm.yaml
@@ -74,8 +74,6 @@ spec:
         serviceMonitor:
           enabled: true
 
-      service:
-
       route:
         main:
           enabled: true

--- a/kubernetes/apps/base/immich/helm.yaml
+++ b/kubernetes/apps/base/immich/helm.yaml
@@ -175,8 +175,6 @@ spec:
 
     service:
       api:
-        annotations:
-          netbird.io/expose: "true"
         controller: api
         primary: true
         ports:

--- a/kubernetes/apps/base/joplin/helm.yaml
+++ b/kubernetes/apps/base/joplin/helm.yaml
@@ -64,8 +64,6 @@ spec:
     service:
       main:
         controller: main
-        annotations:
-          netbird.io/expose: "true"
         ports:
           http:
             port: 80

--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -60,8 +60,6 @@ spec:
     ingress:
       enabled: false
 
-    service:
-
     # One Uvicorn worker per pod — scale horizontally via replicas (Kubernetes recommendation)
     numWorkers: 1
 

--- a/kubernetes/apps/base/litellm/helm.yaml
+++ b/kubernetes/apps/base/litellm/helm.yaml
@@ -61,8 +61,6 @@ spec:
       enabled: false
 
     service:
-      annotations:
-        netbird.io/expose: "true"
 
     # One Uvicorn worker per pod — scale horizontally via replicas (Kubernetes recommendation)
     numWorkers: 1

--- a/kubernetes/apps/base/openwebui/helm.yaml
+++ b/kubernetes/apps/base/openwebui/helm.yaml
@@ -218,8 +218,6 @@ spec:
     service:
       main:
         controller: main
-        annotations:
-          netbird.io/expose: "true"
         ports:
           http:
             port: 80

--- a/kubernetes/apps/base/paperless/helm.yaml
+++ b/kubernetes/apps/base/paperless/helm.yaml
@@ -213,8 +213,6 @@ spec:
       main:
         # Keep the service name as `paperless` (not `paperless-main`) for compatibility.
         forceRename: paperless
-        annotations:
-          netbird.io/expose: "true"
         controller: main
         ports:
           http:

--- a/kubernetes/apps/base/termix/helm.yaml
+++ b/kubernetes/apps/base/termix/helm.yaml
@@ -63,8 +63,6 @@ spec:
     service:
       main:
         controller: main
-        annotations:
-          netbird.io/expose: "true"
         ports:
           http:
             port: 80

--- a/kubernetes/apps/base/uptime/helm.yaml
+++ b/kubernetes/apps/base/uptime/helm.yaml
@@ -58,8 +58,6 @@ spec:
 
     service:
       main:
-        annotations:
-          netbird.io/expose: "true"
         controller: main
         ports:
           http:

--- a/kubernetes/apps/base/vaultwarden/helm.yaml
+++ b/kubernetes/apps/base/vaultwarden/helm.yaml
@@ -84,8 +84,6 @@ spec:
     # -- Configures service settings for the chart.
     service:
       main:
-        annotations:
-          netbird.io/expose: "true"
         controller: main
         sessionAffinity: ClientIP
         sessionAffinityConfig:


### PR DESCRIPTION
Removes the `netbird.io/expose: "true"` annotation from all base app HelmReleases (vaultwarden, openwebui, immich, authentik, litellm, termix, paperless, uptime, joplin).