### PR TITLE
ci: replace flux-local with flate

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,4 +1,4 @@
-name: Flux Local
+name: Validate Kubernetes Manifests
 
 on:
   pull_request:
@@ -13,47 +13,45 @@ concurrency:
 
 jobs:
   test:
-    name: Flux Local Test
+    name: Flate Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Setup Flux CLI
-        uses: fluxcd/flux2/action@889be9d6cc8afa8ed639e1e1ba4ab678e3b38d8c # v2.9.4
-
-      - name: Flux Local Test
-        uses: allenporter/flux-local/action/test@92d3a538c009c3fec120fbf50f6ef33b3e0a569c # 8.4.0
         with:
-          path: kubernetes/clusters/production
-          enable-helm: true
-          debug: true
+          fetch-depth: 0
+
+      - name: Setup Flate
+        uses: home-operations/flate/action@2862e47ed4d6efebeffb43c7691ee6df06b4536c # v0.5.0
+
+      - name: Flate Test
+        run: flate test all --path kubernetes/clusters/production
 
   diff:
-    name: Flux Local Diff
+    name: Flate Diff
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    strategy:
-      matrix:
-        resources: ["helmrelease", "kustomization"]
-      fail-fast: false
     steps:
       - name: Checkout Pull Request Branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Setup Flux CLI
-        uses: fluxcd/flux2/action@889be9d6cc8afa8ed639e1e1ba4ab678e3b38d8c # v2.9.4
-
-      - name: Flux Local Diff
-        uses: allenporter/flux-local/action/diff@92d3a538c009c3fec120fbf50f6ef33b3e0a569c # 8.4.0
-        id: diff
         with:
-          live-branch: ${{ github.event.repository.default_branch }}
-          path: kubernetes/clusters/production
-          resource: ${{matrix.resources}}
-          sources: flux-system
-          debug: true
+          fetch-depth: 0
+
+      - name: Setup Flate
+        uses: home-operations/flate/action@2862e47ed4d6efebeffb43c7691ee6df06b4536c # v0.5.0
+        with:
+          base: ${{ github.event.repository.default_branch }}
+
+      - name: Flate Diff
+        id: diff
+        run: |
+          flate diff all --path kubernetes/clusters/production -o diff > diff.txt
+          {
+            echo 'diff<<EOF'
+            cat diff.txt
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate Token
         if: ${{ steps.diff.outputs.diff != '' }}
@@ -68,7 +66,7 @@ jobs:
         uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3.12.0
         with:
           repo-token: "${{ steps.app-token.outputs.token }}"
-          message-id: "${{ github.event.pull_request.number }}/kubernetes/${{ matrix.resources }}"
+          message-id: "${{ github.event.pull_request.number }}/kubernetes"
           message-failure: Diff was not successful
           message: |
             ```diff

--- a/.taskfiles/kubernetes/flux/Taskfile.yaml
+++ b/.taskfiles/kubernetes/flux/Taskfile.yaml
@@ -20,25 +20,27 @@ tasks:
   diff:
     desc: Output the diff of the current changes
     cmds:
-      - flux-local diff ks --sources flux-system --path {{.PATH}}
-      - flux-local diff hr --sources flux-system --path {{.PATH}}
+      - flate diff ks --sources flux-system --path {{.PATH}}
+      - flate diff hr --sources flux-system --path {{.PATH}}
     vars:
       PATH: "kubernetes/clusters/production"
     preconditions:
-      - sh: which flux-local
-        msg: flux-local is not installed
+      - sh: which flate
+        msg: flate is not installed
       - sh: which flux
         msg: flux is not installed
 
   test:
     desc: Verify that resources are valid
+    env:
+      FLATE_LOG_LEVEL: "{{if .CLI_VERBOSE}}debug{{else}}info{{end}}"
     cmds:
-      - flux-local test --all-namespaces --path {{.PATH}} --enable-helm {{if .CLI_VERBOSE}}--verbose{{end}}
+      - flate test all --path {{.PATH}}
     vars:
       PATH: "kubernetes/clusters/production"
     preconditions:
-      - sh: which flux-local
-        msg: flux-local is not installed
+      - sh: which flate
+        msg: flate is not installed
       - sh: which flux
         msg: flux is not installed
 

--- a/kubernetes/apps/overlays/prd/kustomization.yaml
+++ b/kubernetes/apps/overlays/prd/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+components:
+  - ../../../components/substitute
+
 labels:
   - pairs:
       app.kubernetes.io/category: apps


### PR DESCRIPTION
## What

Replace `flux-local` with [flate](https://github.com/home-operations/flate) for Kubernetes manifest validation and diffing.

## Changes

- **CI workflow** — rename `flux-local.yaml` → `validate.yaml`; swap the `flux-local` test/diff actions for the `home-operations/flate/action` + `flate test all` / `flate diff all` commands. Added `fetch-depth: 0` to checkouts so flate can resolve the `main` baseline.
- **Taskfile** — `task kubernetes:flux:diff` / `test` now use `flate` instead of `flux-local`.
- **Apps overlay** — add the `substitute` component to `kubernetes/apps/overlays/prd/kustomization.yaml` so changed-only mode can resolve the `settings`/`secrets` producers referenced by `postBuild.substituteFrom`.

## Why

flate is a single static binary (no cluster, no `helm`/`kustomize`/`flux` CLIs) and runs in CI in seconds rather than minutes. The `substitute` component addition is required for flate's changed-only diff mode to find the ConfigMap/Secret producers when only a subset of Kustomizations change.

## Notes

- The `diff` job compares against `main`; on this PR the baseline side still lacks the `substitute` component, so the diff check may report a blocked `settings` dependency until this merges. Subsequent PRs diff cleanly.
- The Sure app changes live on a separate branch (`feat/add-sure`).