### PR TITLE
feat(coredns): manage CoreDNS through Flux

### DIFF
--- a/kubernetes/apps/overlays/dev/kustomization.yaml
+++ b/kubernetes/apps/overlays/dev/kustomization.yaml
@@ -5,10 +5,10 @@ labels:
       app.kubernetes.io/category: apps
       app.kubernetes.io/environment: dev
 
-resources:
+resources: []
   # - authentik
   # - harbor
-  - immich
+  # - immich
   # - joplin
   # - litellm
   # - n8n

--- a/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
@@ -44,6 +44,7 @@ spec:
               lameduck 5s
           - name: ready
           - name: log
+            parameters: .
             configBlock: |-
               class error
           - name: prometheus

--- a/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
@@ -31,6 +31,9 @@ spec:
     service:
       name: kube-dns
       clusterIP: 10.96.0.10
+    prometheus:
+      service:
+        enabled: true
     servers:
       - zones:
           - zone: .
@@ -51,16 +54,15 @@ spec:
           - name: kubernetes
             parameters: cluster.local in-addr.arpa ip6.arpa
             configBlock: |-
-              pods verified
+              pods insecure
               fallthrough in-addr.arpa ip6.arpa
+              ttl 30
           - name: forward
             parameters: . /etc/resolv.conf
             configBlock: |-
               max_concurrent 1000
           - name: cache
-            configBlock: |-
-              prefetch 20
-              serve_stale
+            parameters: 30
           - name: loop
           - name: reload
           - name: loadbalance

--- a/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
@@ -30,7 +30,7 @@ spec:
       create: true
     service:
       name: kube-dns
-      clusterIP: 10.43.0.10
+      clusterIP: 10.96.0.10
     servers:
       - zones:
           - zone: .

--- a/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
@@ -1,0 +1,82 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: coredns
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.47.0
+  url: oci://ghcr.io/coredns/charts/coredns
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: coredns
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: coredns
+  values:
+    fullnameOverride: coredns
+    image:
+      repository: registry.k8s.io/coredns/coredns
+    replicaCount: 2
+    k8sAppLabelOverride: kube-dns
+    serviceAccount:
+      create: true
+    service:
+      name: kube-dns
+      clusterIP: 10.43.0.10
+    servers:
+      - zones:
+          - zone: .
+            scheme: dns://
+            use_tcp: true
+        port: 53
+        plugins:
+          - name: errors
+          - name: health
+            configBlock: |-
+              lameduck 5s
+          - name: ready
+          - name: log
+            configBlock: |-
+              class error
+          - name: prometheus
+            parameters: :9153
+          - name: kubernetes
+            parameters: cluster.local in-addr.arpa ip6.arpa
+            configBlock: |-
+              pods verified
+              fallthrough in-addr.arpa ip6.arpa
+          - name: forward
+            parameters: . /etc/resolv.conf
+            configBlock: |-
+              max_concurrent 1000
+          - name: cache
+            configBlock: |-
+              prefetch 20
+              serve_stale
+          - name: loop
+          - name: reload
+          - name: loadbalance
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists

--- a/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
@@ -82,3 +82,7 @@ spec:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
+    deployment:
+      selector:
+        matchLabels:
+          k8s-app: kube-dns

--- a/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
@@ -37,7 +37,6 @@ spec:
     servers:
       - zones:
           - zone: .
-            scheme: dns://
             use_tcp: true
         port: 53
         plugins:
@@ -63,6 +62,9 @@ spec:
               max_concurrent 1000
           - name: cache
             parameters: 30
+            configBlock: |-
+              disable success cluster.local
+              disable denial cluster.local
           - name: loop
           - name: reload
           - name: loadbalance

--- a/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/app/helm.yaml
@@ -22,8 +22,6 @@ spec:
     name: coredns
   values:
     fullnameOverride: coredns
-    image:
-      repository: registry.k8s.io/coredns/coredns
     replicaCount: 2
     k8sAppLabelOverride: kube-dns
     serviceAccount:

--- a/kubernetes/infrastructure/base/networking/coredns/app/kustomization.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - helm.yaml

--- a/kubernetes/infrastructure/base/networking/coredns/ks.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/ks.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app coredns
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/module: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  path: ./kubernetes/infrastructure/base/networking/coredns/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  timeout: 5m

--- a/kubernetes/infrastructure/base/networking/coredns/kustomization.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kube-system
+
+components:
+  - ../../../../components/substitute
+
+resources:
+  - ks.yaml
+  - namespace.yaml

--- a/kubernetes/infrastructure/base/networking/coredns/kustomization.yaml
+++ b/kubernetes/infrastructure/base/networking/coredns/kustomization.yaml
@@ -8,4 +8,3 @@ components:
 
 resources:
   - ks.yaml
-  - namespace.yaml

--- a/kubernetes/infrastructure/base/networking/kustomization.yaml
+++ b/kubernetes/infrastructure/base/networking/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
   - envoy-gateway
   - cilium
   - external-dns
-  - coredns
+  # - coredns
   # - netbird
   - maddy

--- a/kubernetes/infrastructure/base/networking/kustomization.yaml
+++ b/kubernetes/infrastructure/base/networking/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - envoy-gateway
   - cilium
   - external-dns
+  - coredns
   # - netbird
   - maddy

--- a/kubernetes/infrastructure/base/networking/kustomization.yaml
+++ b/kubernetes/infrastructure/base/networking/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
   - envoy-gateway
   - cilium
   - external-dns
-  # - coredns
+  - coredns
   # - netbird
   - maddy

--- a/kubernetes/infrastructure/overlays/dev/kustomization.yaml
+++ b/kubernetes/infrastructure/overlays/dev/kustomization.yaml
@@ -1,249 +1,256 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 labels:
-- pairs:
-    app.kubernetes.io/category: infrastructure
-    app.kubernetes.io/environment: dev
+  - pairs:
+      app.kubernetes.io/category: infrastructure
+      app.kubernetes.io/environment: dev
 patches:
-- path: ./secrets.sops.yaml
-  target:
-    kind: Secret
-    name: secrets
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/security/external-secrets/store
-  target:
-    kind: Kustomization
-    name: external-secrets-store
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/networking/cilium/config
-  target:
-    kind: Kustomization
-    name: cilium-config
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/networking/envoy-gateway/config
-  target:
-    kind: Kustomization
-    name: envoy-gateway-config
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/platform/flux/instance
-  target:
-    kind: Kustomization
-    name: flux-instance
-- patch: |-
-    $patch: delete
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
+  - path: ./secrets.sops.yaml
+    target:
+      kind: Secret
+      name: secrets
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/networking/coredns/app
+    target:
+      kind: Kustomization
+      name: coredns
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/security/external-secrets/store
+    target:
+      kind: Kustomization
+      name: external-secrets-store
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/networking/cilium/config
+    target:
+      kind: Kustomization
+      name: cilium-config
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/networking/envoy-gateway/config
+    target:
+      kind: Kustomization
+      name: envoy-gateway-config
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/platform/flux/instance
+    target:
+      kind: Kustomization
+      name: flux-instance
+  - patch: |-
+      $patch: delete
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: cilium
+        namespace: cilium-system
+    target:
+      kind: Kustomization
       name: cilium
-      namespace: cilium-system
-  target:
-    kind: Kustomization
-    name: cilium
-- patch: |-
-    - op: remove
-      path: /spec/dependsOn
-  target:
-    kind: Kustomization
-    name: cilium-config
-- patch: |-
-    - op: remove
-      path: /spec/dependsOn
-  target:
-    kind: Kustomization
-    name: cilium-policies
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/networking/external-dns/app
-  target:
-    kind: Kustomization
-    name: external-dns
-- patch: |-
-    $patch: delete
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
+  - patch: |-
+      - op: remove
+        path: /spec/dependsOn
+    target:
+      kind: Kustomization
+      name: cilium-config
+  - patch: |-
+      - op: remove
+        path: /spec/dependsOn
+    target:
+      kind: Kustomization
+      name: cilium-policies
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/networking/external-dns/app
+    target:
+      kind: Kustomization
+      name: external-dns
+  - patch: |-
+      $patch: delete
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: prometheus
+        namespace: monitoring
+    target:
+      kind: Kustomization
       name: prometheus
-      namespace: monitoring
-  target:
-    kind: Kustomization
-    name: prometheus
-- patch: |-
-    $patch: delete
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
+  - patch: |-
+      $patch: delete
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: metrics-server
+        namespace: metrics-server
+    target:
+      kind: Kustomization
       name: metrics-server
-      namespace: metrics-server
-  target:
-    kind: Kustomization
-    name: metrics-server
-- patch: |-
-    $patch: delete
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
+  - patch: |-
+      $patch: delete
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: netbird-operator
+        namespace: netbird
+    target:
+      kind: Kustomization
       name: netbird-operator
-      namespace: netbird
-  target:
-    kind: Kustomization
-    name: netbird-operator
-- patch: |-
-    $patch: delete
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
+  - patch: |-
+      $patch: delete
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: netbird-operator-config
+        namespace: netbird
+    target:
+      kind: Kustomization
       name: netbird-operator-config
-      namespace: netbird
-  target:
-    kind: Kustomization
-    name: netbird-operator-config
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/storage/rook/cluster
-    - op: add
-      path: /spec/healthChecks
-      value:
-        - apiVersion: helm.toolkit.fluxcd.io/v2
-          kind: HelmRelease
-          name: rook-ceph-cluster
-          namespace: rook-ceph
-        - apiVersion: ceph.rook.io/v1
-          kind: CephCluster
-          name: rook-ceph
-          namespace: rook-ceph
-  target:
-    kind: Kustomization
-    name: rook-ceph-cluster
-- patch: |-
-    $patch: delete
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/storage/rook/cluster
+      - op: add
+        path: /spec/healthChecks
+        value:
+          - apiVersion: helm.toolkit.fluxcd.io/v2
+            kind: HelmRelease
+            name: rook-ceph-cluster
+            namespace: rook-ceph
+          - apiVersion: ceph.rook.io/v1
+            kind: CephCluster
+            name: rook-ceph
+            namespace: rook-ceph
+    target:
+      kind: Kustomization
+      name: rook-ceph-cluster
+  - patch: |-
+      $patch: delete
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: nfs-subdir
+        namespace: nfs-subdir
+    target:
+      kind: Kustomization
       name: nfs-subdir
-      namespace: nfs-subdir
-  target:
-    kind: Kustomization
-    name: nfs-subdir
-- patch: |-
-    $patch: delete
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
+  - patch: |-
+      $patch: delete
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: local-path-storage
+        namespace: local-path-storage
+    target:
+      kind: Kustomization
       name: local-path-storage
-      namespace: local-path-storage
-  target:
-    kind: Kustomization
-    name: local-path-storage
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/observability/thanos/app
-  target:
-    kind: Kustomization
-    name: thanos
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/observability/loki/app
-  target:
-    kind: Kustomization
-    name: loki
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/observability/prometheus/app
-  target:
-    kind: Kustomization
-    name: prometheus
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/observability/grafana/app
-  target:
-    kind: Kustomization
-    name: grafana
-- patch: |-
-    - op: replace
-      path: /spec/path
-      value: ./kubernetes/infrastructure/overlays/dev/observability/alloy/app
-  target:
-    kind: Kustomization
-    name: alloy
-- patch: |-
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
-      name: _
-    spec:
-      deletionPolicy: WaitForTermination
-      patches:
-        - patch: |-
-            apiVersion: helm.toolkit.fluxcd.io/v2
-            kind: HelmRelease
-            metadata:
-              name: _
-            spec:
-              install:
-                crds: CreateReplace
-              rollback:
-                cleanupOnFail: true
-              upgrade:
-                cleanupOnFail: true
-                crds: CreateReplace
-                strategy:
-                  name: RemediateOnFailure
-                remediation:
-                  remediateLastFailure: true
-                  retries: 2
-          target:
-            group: helm.toolkit.fluxcd.io
-            kind: HelmRelease
-  target:
-    group: kustomize.toolkit.fluxcd.io
-    kind: Kustomization
-- patch: |-
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
-      name: not-used
-    spec:
-      decryption:
-        provider: sops
-  target:
-    group: kustomize.toolkit.fluxcd.io
-    kind: Kustomization
-- patch: |-
-    apiVersion: kustomize.toolkit.fluxcd.io/v1
-    kind: Kustomization
-    metadata:
-      name: not-used
-    spec:
-      postBuild:
-        substituteFrom:
-          - kind: ConfigMap
-            name: settings
-            optional: false
-          - kind: Secret
-            name: secrets
-            optional: false
-  target:
-    group: kustomize.toolkit.fluxcd.io
-    kind: Kustomization
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/observability/thanos/app
+    target:
+      kind: Kustomization
+      name: thanos
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/observability/loki/app
+    target:
+      kind: Kustomization
+      name: loki
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/observability/prometheus/app
+    target:
+      kind: Kustomization
+      name: prometheus
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/observability/grafana/app
+    target:
+      kind: Kustomization
+      name: grafana
+  - patch: |-
+      - op: replace
+        path: /spec/path
+        value: ./kubernetes/infrastructure/overlays/dev/observability/alloy/app
+    target:
+      kind: Kustomization
+      name: alloy
+  - patch: |-
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: _
+      spec:
+        deletionPolicy: WaitForTermination
+        patches:
+          - patch: |-
+              apiVersion: helm.toolkit.fluxcd.io/v2
+              kind: HelmRelease
+              metadata:
+                name: _
+              spec:
+                install:
+                  crds: CreateReplace
+                rollback:
+                  cleanupOnFail: true
+                upgrade:
+                  cleanupOnFail: true
+                  crds: CreateReplace
+                  strategy:
+                    name: RemediateOnFailure
+                  remediation:
+                    remediateLastFailure: true
+                    retries: 2
+            target:
+              group: helm.toolkit.fluxcd.io
+              kind: HelmRelease
+    target:
+      group: kustomize.toolkit.fluxcd.io
+      kind: Kustomization
+  - patch: |-
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: not-used
+      spec:
+        decryption:
+          provider: sops
+    target:
+      group: kustomize.toolkit.fluxcd.io
+      kind: Kustomization
+  - patch: |-
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: not-used
+      spec:
+        postBuild:
+          substituteFrom:
+            - kind: ConfigMap
+              name: settings
+              optional: false
+            - kind: Secret
+              name: secrets
+              optional: false
+    target:
+      group: kustomize.toolkit.fluxcd.io
+      kind: Kustomization
 resources:
-- ../../base/security
-- ../../base/databases
-- ../../base/observability/prometheus
-- ../../base/observability/namespace.yaml
-- ../../base/platform
-- ../../base/networking
-- ../../base/storage
+  - ../../base/security
+  - ../../base/databases
+  - ../../base/observability/prometheus
+  - ../../base/observability/namespace.yaml
+  - ../../base/platform
+  - ../../base/networking
+  - ../../base/storage

--- a/kubernetes/infrastructure/overlays/dev/networking/coredns/app/helm.yaml
+++ b/kubernetes/infrastructure/overlays/dev/networking/coredns/app/helm.yaml
@@ -1,0 +1,32 @@
+- op: replace
+  path: /spec/values/servers/0/plugins
+  value:
+    - name: errors
+    - name: health
+      configBlock: |-
+        lameduck 5s
+    - name: ready
+    - name: log
+      configBlock: |-
+        class error
+    - name: prometheus
+      parameters: :9153
+    - name: kubernetes
+      parameters: cluster.local in-addr.arpa ip6.arpa
+      configBlock: |-
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+        ttl 30
+    - name: hosts
+      configBlock: |-
+        192.168.39.1 host.minikube.internal
+        fallthrough
+    - name: forward
+      parameters: . /etc/resolv.conf
+      configBlock: |-
+        max_concurrent 1000
+    - name: cache
+      parameters: 30
+    - name: loop
+    - name: reload
+    - name: loadbalance

--- a/kubernetes/infrastructure/overlays/dev/networking/coredns/app/helm.yaml
+++ b/kubernetes/infrastructure/overlays/dev/networking/coredns/app/helm.yaml
@@ -27,6 +27,9 @@
         max_concurrent 1000
     - name: cache
       parameters: 30
+      configBlock: |-
+        disable success cluster.local
+        disable denial cluster.local
     - name: loop
     - name: reload
     - name: loadbalance

--- a/kubernetes/infrastructure/overlays/dev/networking/coredns/app/kustomization.yaml
+++ b/kubernetes/infrastructure/overlays/dev/networking/coredns/app/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../../base/networking/coredns/app
+
+patches:
+  - target:
+      kind: HelmRelease
+      name: coredns
+    path: helm.yaml

--- a/kubernetes/infrastructure/overlays/dev/platform/flux/instance/helm.yaml
+++ b/kubernetes/infrastructure/overlays/dev/platform/flux/instance/helm.yaml
@@ -7,4 +7,4 @@ spec:
     instance:
       sync:
         path: kubernetes/clusters/dev
-        ref: refs/heads/renovate/major-immich
+        ref: refs/heads/feat/coredns/flux


### PR DESCRIPTION
## Summary

Manage CoreDNS through Flux instead of manual configuration.

## Changes

- Add CoreDNS app manifests under `kubernetes/infrastructure/base/networking/coredns/`
- Add dev overlay patches for CoreDNS
- Add monitoring service for CoreDNS
- Clean up inexistent resources in the dev overlay
- Point the dev Flux instance at this branch for testing

## Notes

- Dev overlay `kustomization.yaml` was reformatted (indentation) alongside the CoreDNS additions
- The dev Flux instance branch ref is temporarily set to `feat/coredns/flux` for testing